### PR TITLE
Fix source address determination

### DIFF
--- a/helpers/http-formatters.js
+++ b/helpers/http-formatters.js
@@ -9,8 +9,6 @@ function formatHttpRequest (ecs, req) {
     id,
     method,
     url,
-    remoteAddress,
-    remotePort,
     headers,
     hostname,
     httpVersion,

--- a/helpers/http-formatters.js
+++ b/helpers/http-formatters.js
@@ -57,6 +57,17 @@ function formatHttpRequest (ecs, req) {
     ecs.client.port = remotePort
   }
 
+  ecs.client = ecs.client || {}
+  // if req.ip exists from framework (Express, etc.), defer to that i.e. http://expressjs.com/en/4x/api.html
+  if (req.ip) {
+    ecs.client.address = req.ip
+  } else if (headers['x-forwarded-for']) {
+    ecs.client.address = req.headers['x-forwarded-for'].split(',')[0]
+  } else if (socket && socket.remoteAddress) {
+    ecs.client.address = socket.remoteAddress
+    ecs.client.address = socket.remotePort
+  }
+
   var hasHeaders = Object.keys(headers).length > 0
   if (hasHeaders === true) {
     ecs.http.request.headers = ecs.http.request.headers || {}

--- a/helpers/http-formatters.js
+++ b/helpers/http-formatters.js
@@ -51,18 +51,10 @@ function formatHttpRequest (ecs, req) {
     if (port) ecs.url.port = Number(port)
   }
 
-  if (remoteAddress || remotePort) {
-    ecs.client = ecs.client || {}
-    ecs.client.address = remoteAddress
-    ecs.client.port = remotePort
-  }
-
   ecs.client = ecs.client || {}
   // if req.ip exists from framework (Express, etc.), defer to that i.e. http://expressjs.com/en/4x/api.html
   if (req.ip) {
     ecs.client.address = req.ip
-  } else if (headers['x-forwarded-for']) {
-    ecs.client.address = req.headers['x-forwarded-for'].split(',')[0]
   } else if (socket && socket.remoteAddress) {
     ecs.client.address = socket.remoteAddress
     ecs.client.address = socket.remotePort

--- a/helpers/http-formatters.js
+++ b/helpers/http-formatters.js
@@ -55,7 +55,7 @@ function formatHttpRequest (ecs, req) {
     ecs.client.address = req.ip
   } else if (socket && socket.remoteAddress) {
     ecs.client.address = socket.remoteAddress
-    ecs.client.address = socket.remotePort
+    ecs.client.port = socket.remotePort
   }
 
   var hasHeaders = Object.keys(headers).length > 0


### PR DESCRIPTION
As discussed in https://github.com/elastic/ecs-logging-js/issues/18, the current method of determining a source IP address is unreliable. 

This update will use `req.ip` if available from a framework (Express, etc.):
![image](https://user-images.githubusercontent.com/6659148/98736883-0bb7cd80-236b-11eb-98aa-01feb3a7c716.png)

Otherwise, attempt to determine the `remoteAddress`/`remotePort` from the socket.

Closes #18 