### PR TITLE
Check for socket being available

### DIFF
--- a/helpers/http-formatters.js
+++ b/helpers/http-formatters.js
@@ -28,7 +28,7 @@ function formatHttpRequest (ecs, req) {
   ecs.http.request.method = method.toLowerCase()
 
   ecs.url = ecs.url || {}
-  ecs.url.full = (socket.encrypted ? 'https://' : 'http://') + headers.host + url
+  ecs.url.full = (socket && socket.encrypted ? 'https://' : 'http://') + headers.host + url
   var hasQuery = url.indexOf('?')
   var hasAnchor = url.indexOf('#')
   if (hasQuery > -1 && hasAnchor > -1) {


### PR DESCRIPTION
Hapi will not provide the value of socket and this line causes this error:

```
TypeError: Cannot read property 'encrypted' of undefined
 at formatHttpRequest (.\node_modules\@elastic\ecs-helpers\http-formatters.js:31:26)
```