### PR TITLE
feat: add 'apmIntegration: false' option to disable Elastic APM integration

### DIFF
--- a/docs/morgan.asciidoc
+++ b/docs/morgan.asciidoc
@@ -134,9 +134,10 @@ const app = require('express')()
 const morgan = require('morgan')
 const ecsFormat = require('@elastic/ecs-morgan-format')
 
-app.use(morgan(ecsFormat('tiny'))) <1>
+app.use(morgan(ecsFormat({ format: 'tiny' }))) <1>
 // ...
 ----
+<1> If "format" is the only option you are using, you may pass it as `ecsFormat('tiny')`.
 
 [float]
 [[morgan-log-level]]
@@ -194,3 +195,11 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/master/l
 ----
 
 These IDs match trace data reported by the APM agent.
+
+Integration with Elastic APM can be explicitly disabled via the
+`apmIntegration: false` option, for example:
+
+[source,js]
+----
+app.use(morgan(ecsFormat({ apmIntegration: false })))
+----

--- a/docs/pino.asciidoc
+++ b/docs/pino.asciidoc
@@ -240,6 +240,14 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/master/l
 
 These IDs match trace data reported by the APM agent.
 
+Integration with Elastic APM can be explicitly disabled via the
+`apmIntegration: false` option, for example:
+
+[source,js]
+----
+const log = pino(ecsFormat({ apmIntegration: false }))
+----
+
 
 [float]
 [[pino-considerations]]

--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -254,3 +254,14 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/master/l
 ----
 
 These IDs match trace data reported by the APM agent.
+
+Integration with Elastic APM can be explicitly disabled via the
+`apmIntegration: false` option, for example:
+
+[source,js]
+----
+const logger = winston.createLogger({
+  format: ecsFormat({ apmIntegration: false }),
+  // ...
+})
+----

--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `apmIntegration: false` option to all ecs-logging formatters to
+  enable explicitly disabling Elastic APM integration.
+
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))
 

--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `apmIntegration: false` option to all ecs-logging formatters to
   enable explicitly disabling Elastic APM integration.
+  ([#62](https://github.com/elastic/ecs-logging-nodejs/pull/62))
 
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))

--- a/loggers/morgan/test/apm.test.js
+++ b/loggers/morgan/test/apm.test.js
@@ -179,3 +179,148 @@ test('tracing integration works', t => {
     })
   })
 })
+
+// This is the same as the previous test, but sets `apmIntegration=false`
+// and asserts tracing fields are *not* added to log records.
+test('apmIntegration=false disables tracing integration', t => {
+  let apmServer
+  let app
+  let appIsClosed = false
+  const traceObjs = []
+  const logObjs = []
+  let stderr = ''
+
+  // 1. Setup a mock APM server to accept trace data. Callback when listening.
+  //    Pass intake data to `collectTracesLogsAndCheck()`.
+  function step1StartMockApmServer (cb) {
+    apmServer = http.createServer(function apmServerReq (req, res) {
+      t.equal(req.method, 'POST')
+      t.equal(req.url, '/intake/v2/events')
+      let instream = req
+      if (req.headers['content-encoding'] === 'gzip') {
+        instream = req.pipe(zlib.createGunzip())
+      } else {
+        instream.setEncoding('utf8')
+      }
+      instream.pipe(split(JSON.parse)).on('data', function (traceObj) {
+        collectTracesLogsAndCheck(traceObj, null)
+      })
+      req.on('end', function () {
+        res.end('ok')
+      })
+    })
+    apmServer.listen(0, function () {
+      cb(null, 'http://localhost:' + apmServer.address().port)
+    })
+  }
+
+  // 2. Start a test app that uses APM and our mock APM Server.
+  //    Callback on first log line, which includes the app's HTTP address.
+  //    Pass parsed JSON log records to `collectTracesLogsAndCheck()`.
+  function step2StartApp (apmServerUrl, cb) {
+    app = spawn(
+      process.execPath,
+      [
+        path.join(__dirname, 'serve-one-http-req-with-apm.js'),
+        apmServerUrl,
+        'true' // disableApmIntegration argument
+      ]
+    )
+    let handledFirstLogLine = false
+    app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
+      if (!handledFirstLogLine) {
+        handledFirstLogLine = true
+        t.equal(logObj.message, 'listening')
+        t.ok(logObj.address, 'first listening log line has "address"')
+        cb(null, logObj.address)
+      } else {
+        collectTracesLogsAndCheck(null, logObj)
+      }
+    })
+    app.stderr.on('data', function (chunk) {
+      stderr += chunk
+    })
+    app.on('close', function (code) {
+      t.equal(stderr, '', 'empty stderr from app')
+      t.equal(code, 0, 'app exited 0')
+      appIsClosed = true
+    })
+  }
+
+  // 3. Call the test app to generate a trace.
+  function step3CallApp (appUrl, cb) {
+    const req = http.request(appUrl + '/', function (res) {
+      res.on('data', function () {})
+      res.on('end', cb)
+    })
+    req.on('error', cb)
+    req.end()
+  }
+
+  // 4. Collect trace data from the APM Server, log data from the app, and when
+  // all the expected data is collected, then test it: assert matching tracing
+  // IDs.
+  function collectTracesLogsAndCheck (traceObj, logObj) {
+    if (traceObj) {
+      traceObjs.push(traceObj)
+    }
+    if (logObj) {
+      t.ok(validate(logObj), 'logObj is ECS valid')
+      t.equal(ecsLoggingValidate(logObj), null)
+      logObjs.push(logObj)
+    }
+    // Unlike the equivalent apm.test.js for other logging frameworks, we are
+    // not testing for a custom span and `$logRecord.span.id` because the way
+    // morgan logs (on the HTTP Response "finished" event), a custom span in
+    // the request handler is no longer active.
+    if (traceObjs.length >= 2 && logObjs.length >= 1) {
+      t.ok(traceObjs[0].metadata, 'traceObjs[0] is metadata')
+      t.ok(traceObjs[1].transaction, 'traceObjs[1] is transaction')
+      t.notOk(logObjs[0].trace, 'log record does *not* have "trace" object')
+      t.notOk(logObjs[0].transaction, 'log record does *not* have "transaction" object')
+      t.notOk(logObjs[0].span, 'log record does *not* have "span" object')
+      t.notOk(logObjs[0].service, 'log record does *not* have "service" object')
+      t.notOk(logObjs[0].event, 'log record does *not* have "event" object')
+      finish()
+    }
+  }
+
+  function finish () {
+    if (appIsClosed) {
+      apmServer.close(function () {
+        t.end()
+      })
+    } else {
+      app.on('close', function () {
+        apmServer.close(function () {
+          t.end()
+        })
+      })
+    }
+  }
+
+  step1StartMockApmServer(function onListening (apmServerErr, apmServerUrl) {
+    t.ifErr(apmServerErr)
+    if (apmServerErr) {
+      finish()
+      return
+    }
+    t.ok(apmServerUrl, 'apmServerUrl: ' + apmServerUrl)
+
+    step2StartApp(apmServerUrl, function onReady (appErr, appUrl) {
+      t.ifErr(appErr)
+      if (appErr) {
+        finish()
+        return
+      }
+      t.ok(appUrl, 'appUrl: ' + appUrl)
+
+      step3CallApp(appUrl, function (clientErr) {
+        t.ifErr(clientErr)
+
+        // The thread of control now is expected to be in
+        // `collectTracesLogsAndCheck()`.
+      })
+    })
+  })
+})

--- a/loggers/morgan/test/basic.test.js
+++ b/loggers/morgan/test/basic.test.js
@@ -159,6 +159,25 @@ test('"format" argument - format function', t => {
   })
 })
 
+test('"opts.format" argument', t => {
+  t.plan(2)
+
+  // Example:
+  //  POST /?foo=bar 200 - - 0.073 ms
+  const format = 'tiny' // https://github.com/expressjs/morgan#tiny
+  const msgRe = /^POST \/\?foo=bar 200 - - \d+\.\d+ ms$/
+  const stream = split().on('data', line => {
+    const rec = JSON.parse(line)
+    t.match(rec.message, msgRe, 'rec.message')
+  })
+  const logger = morgan(ecsFormat({ format: format }), { stream })
+
+  makeExpressServerAndRequest(logger, '/?foo=bar', { method: 'POST' }, 'hi', function (err) {
+    t.ifErr(err)
+    t.end()
+  })
+})
+
 test('"log.level" for successful response is "info"', t => {
   t.plan(2)
 

--- a/loggers/morgan/test/serve-one-http-req-with-apm.js
+++ b/loggers/morgan/test/serve-one-http-req-with-apm.js
@@ -29,6 +29,7 @@
 // - exit
 
 const serverUrl = process.argv[2]
+const disableApmIntegration = process.argv[3] === 'true'
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
@@ -43,7 +44,11 @@ const http = require('http')
 const morgan = require('morgan')
 const ecsFormat = require('../') // @elastic/ecs-morgan-format
 
-app.use(morgan(ecsFormat()))
+const ecsOpts = {}
+if (disableApmIntegration) {
+  ecsOpts.apmIntegration = false
+}
+app.use(morgan(ecsFormat(ecsOpts)))
 
 app.get('/', function (req, res) {
   res.once('finish', function apmFlushAndExit () {

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `apmIntegration: false` option to all ecs-logging formatters to
+  enable explicitly disabling Elastic APM integration.
+
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))
 

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `apmIntegration: false` option to all ecs-logging formatters to
   enable explicitly disabling Elastic APM integration.
+  ([#62](https://github.com/elastic/ecs-logging-nodejs/pull/62))
 
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))

--- a/loggers/pino/test/apm.test.js
+++ b/loggers/pino/test/apm.test.js
@@ -178,6 +178,148 @@ test('tracing integration works', t => {
   })
 })
 
+// This is the same as the previous test, but sets `apmIntegration=false`
+// and asserts tracing fields are *not* added to log records.
+test('apmIntegration=false disables tracing integration', t => {
+  let apmServer
+  let app
+  let appIsClosed = false
+  const traceObjs = []
+  const logObjs = []
+  let stderr = ''
+
+  // 1. Setup a mock APM server to accept trace data. Callback when listening.
+  //    Pass intake data to `collectTracesLogsAndCheck()`.
+  function step1StartMockApmServer (cb) {
+    apmServer = http.createServer(function apmServerReq (req, res) {
+      t.equal(req.method, 'POST')
+      t.equal(req.url, '/intake/v2/events')
+      let instream = req
+      if (req.headers['content-encoding'] === 'gzip') {
+        instream = req.pipe(zlib.createGunzip())
+      } else {
+        instream.setEncoding('utf8')
+      }
+      instream.pipe(split(JSON.parse)).on('data', function (traceObj) {
+        collectTracesLogsAndCheck(traceObj, null)
+      })
+      req.on('end', function () {
+        res.end('ok')
+      })
+    })
+    apmServer.listen(0, function () {
+      cb(null, 'http://localhost:' + apmServer.address().port)
+    })
+  }
+
+  // 2. Start a test app that uses APM and our mock APM Server.
+  //    Callback on first log line, which includes the app's HTTP address.
+  //    Pass parsed JSON log records to `collectTracesLogsAndCheck()`.
+  function step2StartApp (apmServerUrl, cb) {
+    app = spawn(
+      process.execPath,
+      [
+        path.join(__dirname, 'serve-one-http-req-with-apm.js'),
+        apmServerUrl,
+        'true' // disableApmIntegration argument
+      ]
+    )
+    let handledFirstLogLine = false
+    app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
+      if (!handledFirstLogLine) {
+        handledFirstLogLine = true
+        t.equal(logObj.message, 'listening')
+        t.ok(logObj.address, 'first listening log line has "address"')
+        cb(null, logObj.address)
+      } else {
+        collectTracesLogsAndCheck(null, logObj)
+      }
+    })
+    app.stderr.on('data', function (chunk) {
+      stderr += chunk
+    })
+    app.on('close', function (code) {
+      t.equal(stderr, '', 'empty stderr from app')
+      t.equal(code, 0, 'app exited 0')
+      appIsClosed = true
+    })
+  }
+
+  // 3. Call the test app to generate a trace.
+  function step3CallApp (appUrl, cb) {
+    const req = http.request(appUrl + '/', function (res) {
+      res.on('data', function () {})
+      res.on('end', cb)
+    })
+    req.on('error', cb)
+    req.end()
+  }
+
+  // 4. Collect trace data from the APM Server, log data from the app, and when
+  // all the expected data is collected, then test it: assert matching tracing
+  // IDs.
+  function collectTracesLogsAndCheck (traceObj, logObj) {
+    if (traceObj) {
+      traceObjs.push(traceObj)
+    }
+    if (logObj) {
+      t.ok(validate(logObj), 'logObj is ECS valid')
+      t.equal(ecsLoggingValidate(logObj), null)
+      logObjs.push(logObj)
+    }
+    if (traceObjs.length >= 3 && logObjs.length >= 1) {
+      t.ok(traceObjs[0].metadata, 'traceObjs[0] is metadata')
+      t.ok(traceObjs[1].transaction, 'traceObjs[1] is transaction')
+      t.ok(traceObjs[2].span, 'traceObjs[2] is span')
+      t.notOk(logObjs[0].trace, 'log record does *not* have "trace" object')
+      t.notOk(logObjs[0].transaction, 'log record does *not* have "transaction" object')
+      t.notOk(logObjs[0].span, 'log record does *not* have "span" object')
+      t.notOk(logObjs[0].service, 'log record does *not* have "service" object')
+      t.notOk(logObjs[0].event, 'log record does *not* have "event" object')
+      finish()
+    }
+  }
+
+  function finish () {
+    if (appIsClosed) {
+      apmServer.close(function () {
+        t.end()
+      })
+    } else {
+      app.on('close', function () {
+        apmServer.close(function () {
+          t.end()
+        })
+      })
+    }
+  }
+
+  step1StartMockApmServer(function onListening (apmServerErr, apmServerUrl) {
+    t.ifErr(apmServerErr)
+    if (apmServerErr) {
+      finish()
+      return
+    }
+    t.ok(apmServerUrl, 'apmServerUrl: ' + apmServerUrl)
+
+    step2StartApp(apmServerUrl, function onReady (appErr, appUrl) {
+      t.ifErr(appErr)
+      if (appErr) {
+        finish()
+        return
+      }
+      t.ok(appUrl, 'appUrl: ' + appUrl)
+
+      step3CallApp(appUrl, function (clientErr) {
+        t.ifErr(clientErr)
+
+        // The thread of control now is expected to be in
+        // `collectTracesLogsAndCheck()`.
+      })
+    })
+  })
+})
+
 test('can override service.name, event.dataset', t => {
   execFile(process.execPath, [
     path.join(__dirname, 'use-apm-override-service-name.js'),

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -29,6 +29,7 @@
 // - exit
 
 const serverUrl = process.argv[2]
+const disableApmIntegration = process.argv[3] === 'true'
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
@@ -42,7 +43,11 @@ const http = require('http')
 const ecsFormat = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
-const log = pino({ ...ecsFormat({ convertReqRes: true }) })
+const ecsOpts = { convertReqRes: true }
+if (disableApmIntegration) {
+  ecsOpts.apmIntegration = false
+}
+const log = pino(ecsFormat(ecsOpts))
 
 const server = http.createServer()
 

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `apmIntegration: false` option to all ecs-logging formatters to
+  enable explicitly disabling Elastic APM integration.
+
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))
 

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `apmIntegration: false` option to all ecs-logging formatters to
   enable explicitly disabling Elastic APM integration.
+  ([#62](https://github.com/elastic/ecs-logging-nodejs/pull/62))
 
 - Fix "elasticApm.isStarted is not a function" crash on startup.
   ([#60](https://github.com/elastic/ecs-logging-nodejs/issues/60))

--- a/loggers/winston/test/apm.test.js
+++ b/loggers/winston/test/apm.test.js
@@ -180,6 +180,150 @@ test('tracing integration works', t => {
   })
 })
 
+// This is the same as the previous test, but sets `apmIntegration=false`
+// and asserts tracing fields are *not* added to log records.
+test('apmIntegration=false disables tracing integration', t => {
+  let apmServer
+  let app
+  let appIsClosed = false
+  const traceObjs = []
+  const logObjs = []
+  let stderr = ''
+
+  // 1. Setup a mock APM server to accept trace data. Callback when listening.
+  //    Pass intake data to `collectTracesLogsAndCheck()`.
+  function step1StartMockApmServer (cb) {
+    apmServer = http.createServer(function apmServerReq (req, res) {
+      t.equal(req.method, 'POST')
+      t.equal(req.url, '/intake/v2/events')
+      let instream = req
+      if (req.headers['content-encoding'] === 'gzip') {
+        instream = req.pipe(zlib.createGunzip())
+      } else {
+        instream.setEncoding('utf8')
+      }
+      instream.pipe(split(JSON.parse)).on('data', function (traceObj) {
+        collectTracesLogsAndCheck(traceObj, null)
+      })
+      req.on('end', function () {
+        res.end('ok')
+      })
+    })
+    apmServer.listen(0, function () {
+      cb(null, 'http://localhost:' + apmServer.address().port)
+    })
+  }
+
+  // 2. Start a test app that uses APM and our mock APM Server.
+  //    Callback on first log line, which includes the app's HTTP address.
+  //    Pass parsed JSON log records to `collectTracesLogsAndCheck()`.
+  function step2StartApp (apmServerUrl, cb) {
+    app = spawn(
+      process.execPath,
+      [
+        path.join(__dirname, 'serve-one-http-req-with-apm.js'),
+        apmServerUrl,
+        'true' // disableApmIntegration argument
+      ]
+    )
+    let handledFirstLogLine = false
+    app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
+      if (!handledFirstLogLine) {
+        handledFirstLogLine = true
+        t.equal(logObj.message, 'listening')
+        t.ok(logObj.address, 'first listening log line has "address"')
+        cb(null, logObj.address)
+      } else {
+        collectTracesLogsAndCheck(null, logObj)
+      }
+    })
+    app.stderr.on('data', function (chunk) {
+      stderr += chunk
+    })
+    app.on('close', function (code) {
+      t.equal(stderr, '', 'empty stderr from app')
+      t.equal(code, 0, 'app exited 0')
+      appIsClosed = true
+    })
+  }
+
+  // 3. Call the test app to generate a trace.
+  function step3CallApp (appUrl, cb) {
+    const req = http.request(appUrl + '/', function (res) {
+      res.on('data', function () {})
+      res.on('end', cb)
+    })
+    req.on('error', cb)
+    req.end()
+  }
+
+  // 4. Collect trace data from the APM Server, log data from the app, and when
+  // all the expected data is collected, then test it: assert matching tracing
+  // IDs.
+  function collectTracesLogsAndCheck (traceObj, logObj) {
+    if (traceObj) {
+      traceObjs.push(traceObj)
+      t.comment(`received traceObjs ${traceObjs.length}`)
+    }
+    if (logObj) {
+      t.ok(validate(logObj), 'logObj is ECS valid')
+      t.equal(ecsLoggingValidate(logObj), null, 'logObj is ecs-logging valid')
+      logObjs.push(logObj)
+      t.comment(`received logObjs ${logObjs.length}`)
+    }
+    if (traceObjs.length >= 3 && logObjs.length >= 1) {
+      t.ok(traceObjs[0].metadata, 'traceObjs[0] is metadata')
+      t.ok(traceObjs[1].transaction, 'traceObjs[1] is transaction')
+      t.ok(traceObjs[2].span, 'traceObjs[2] is span')
+      t.notOk(logObjs[0].trace, 'log record does *not* have "trace" object')
+      t.notOk(logObjs[0].transaction, 'log record does *not* have "transaction" object')
+      t.notOk(logObjs[0].span, 'log record does *not* have "span" object')
+      t.notOk(logObjs[0].service, 'log record does *not* have "service" object')
+      t.notOk(logObjs[0].event, 'log record does *not* have "event" object')
+      finish()
+    }
+  }
+
+  function finish () {
+    if (appIsClosed) {
+      apmServer.close(function () {
+        t.end()
+      })
+    } else {
+      app.on('close', function () {
+        apmServer.close(function () {
+          t.end()
+        })
+      })
+    }
+  }
+
+  step1StartMockApmServer(function onListening (apmServerErr, apmServerUrl) {
+    t.ifErr(apmServerErr, 'no error from starting the mock APM server')
+    if (apmServerErr) {
+      finish()
+      return
+    }
+    t.ok(apmServerUrl, 'apmServerUrl: ' + apmServerUrl)
+
+    step2StartApp(apmServerUrl, function onReady (appErr, appUrl) {
+      t.ifErr(appErr, 'no error from starting the app')
+      if (appErr) {
+        finish()
+        return
+      }
+      t.ok(appUrl, 'appUrl: ' + appUrl)
+
+      step3CallApp(appUrl, function (clientErr) {
+        t.ifErr(clientErr, 'no error from calling the app')
+
+        // The thread of control now is expected to be in
+        // `collectTracesLogsAndCheck()`.
+      })
+    })
+  })
+})
+
 test('can override service.name, event.dataset', t => {
   execFile(process.execPath, [
     path.join(__dirname, 'use-apm-override-service-name.js'),

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -29,6 +29,7 @@
 // - exit
 
 const serverUrl = process.argv[2]
+const disableApmIntegration = process.argv[3] === 'true'
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   serverUrl,
@@ -42,9 +43,13 @@ const http = require('http')
 const ecsFormat = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
+const ecsOpts = { convertReqRes: true }
+if (disableApmIntegration) {
+  ecsOpts.apmIntegration = false
+}
 const log = winston.createLogger({
   level: 'info',
-  format: ecsFormat({ convertReqRes: true }),
+  format: ecsFormat(ecsOpts),
   transports: [
     new winston.transports.Console()
   ]


### PR DESCRIPTION
This also changes the argument to the `@elastic/ecs-morgan-format` export to prefer to take an options object.
The old call signature is still supported for backward compat.

Refs: #60