### PR TITLE
fix: usage of 'base' option to pino constructor

### DIFF
--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- Fix handling when the [`base`](https://getpino.io/#/docs/api?id=base-object)
+  option is used to the pino constructor.
+
+  Before this change, using, for example:
+        const log = pino({base: {foo: "bar"}, ...ecsFormat()})
+  would result in two issues:
+  1. The log records would not include the "foo" field.
+  2. The log records would include `"process": {}, "host": {}` for the
+     expected process.pid and os.hostname.
+
+  Further, if the following is used:
+        const log = pino({base: null, ...ecsFormat()})
+  pino does not call `formatters.bindings()` at all, resulting in log
+  records that were missing "ecs.version" (making them invalid ecs-logging
+  records) and part of the APM integration.
+
 - Add `apmIntegration: false` option to all ecs-logging formatters to
   enable explicitly disabling Elastic APM integration.
   ([#62](https://github.com/elastic/ecs-logging-nodejs/pull/62))

--- a/loggers/pino/test/apm.test.js
+++ b/loggers/pino/test/apm.test.js
@@ -331,8 +331,36 @@ test('can override service.name, event.dataset', t => {
     const recs = stdout.trim().split(/\n/g).map(JSON.parse)
     t.equal(recs[0].service.name, 'myname')
     t.equal(recs[0].event.dataset, 'mydataset')
+
+    // If integrating with APM and the log record sets "service.name" to a
+    // non-string or "service" to a non-object, then ecs-pino-format will
+    // overwrite it because it conflicts with the ECS specified type.
     t.equal(recs[1].service.name, 'test-apm')
     t.equal(recs[1].event.dataset, 'test-apm.log')
+    t.equal(recs[2].service.name, 'test-apm')
+    t.equal(recs[2].event.dataset, 'test-apm.log')
+
+    t.equal(recs[3].service.name, 'test-apm')
+    t.equal(recs[3].event.dataset, 'test-apm.log')
+    t.end()
+  })
+})
+
+test('can override service.name, event.dataset in base arg to constructor', t => {
+  execFile(process.execPath, [
+    path.join(__dirname, 'use-apm-override-service-name.js'),
+    'test-apm', // apm "serviceName"
+    'mybindingname' // pino logger "service.name" value for `base` arg
+  ], {
+    timeout: 5000
+  }, function (err, stdout, stderr) {
+    t.ifErr(err)
+    const recs = stdout.trim().split(/\n/g).map(JSON.parse)
+    t.equal(recs[0].service.name, 'myname')
+    t.equal(recs[0].event.dataset, 'mydataset')
+
+    t.equal(recs[3].service.name, 'mybindingname')
+    t.equal(recs[3].event.dataset, 'mybindingname')
     t.end()
   })
 })
@@ -351,8 +379,8 @@ test('unset APM serviceName does not set service.name, event.dataset, but also d
     const recs = stdout.trim().split(/\n/g).map(JSON.parse)
     t.equal(recs[0].service.name, 'myname')
     t.equal(recs[0].event.dataset, 'mydataset')
-    t.equal(recs[1].service, undefined)
-    t.equal(recs[1].event, undefined)
+    t.equal(recs[3].service, undefined)
+    t.equal(recs[3].event, undefined)
     t.end()
   })
 })

--- a/loggers/pino/test/basic.test.js
+++ b/loggers/pino/test/basic.test.js
@@ -100,6 +100,37 @@ test('ecsPinoFormat cases', suite => {
         req: { id: 42 },
         res: { status: 'OK' }
       }
+    },
+    {
+      name: '`base: {}` should avoid "process" and "host" fields',
+      pinoOpts: { base: {}, ...ecsFormat() },
+      loggingFn: (log) => {
+        log.info('hi')
+      },
+      rec: {
+        'log.level': 'info',
+        ecs: { version: ecsVersion },
+        message: 'hi'
+      }
+    },
+    {
+      // The pino docs suggest:
+      // > `base`
+      // > Set to `null` to avoid adding `pid`, `hostname` and `name` properties to each log.
+      //
+      // This results in a given `formatters.bindings` **not getting called** at
+      // all. In earlier versions of this package, that `formatters.bindings`
+      // was used to add fields like "ecs.version".
+      name: '`base: null` should not break ecs-logging format',
+      pinoOpts: { base: null, ...ecsFormat() },
+      loggingFn: (log) => {
+        log.info('hi')
+      },
+      rec: {
+        'log.level': 'info',
+        ecs: { version: ecsVersion },
+        message: 'hi'
+      }
     }
   ]
 

--- a/loggers/pino/test/use-apm-override-service-name.js
+++ b/loggers/pino/test/use-apm-override-service-name.js
@@ -26,6 +26,7 @@
 // - flush APM and exit
 
 const serviceName = process.argv[2] || ''
+const pinoServiceName = process.argv[3] || ''
 /* eslint-disable-next-line no-unused-vars */
 const apm = require('elastic-apm-node').start({
   // Use default serverUrl (fire and forget)
@@ -38,10 +39,12 @@ const apm = require('elastic-apm-node').start({
 const ecsFormat = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
-const log = pino({ ...ecsFormat() })
-log.info({
-  foo: 'bar',
-  service: { name: 'myname' },
-  event: { dataset: 'mydataset' }
-}, 'hi')
-log.info({ foo: 'bar' }, 'bye')
+const pinoOpts = ecsFormat()
+if (pinoServiceName) {
+  pinoOpts.base = { service: { name: pinoServiceName }, event: { dataset: pinoServiceName } }
+}
+const log = pino(pinoOpts)
+log.info({ service: { name: 'myname' }, event: { dataset: 'mydataset' } }, 'override values')
+log.info({ service: { name: 42 }, event: { dataset: 42 } }, 'override values with nums')
+log.info({ service: 'myname', event: 'myevent' }, 'override top-level keys with invalid ECS type')
+log.info('bye')


### PR DESCRIPTION
The 'base' option to pino allows one to change (or null out) the
default "bindings". ecs-format-pino wasn't handling (a) a changed
base, nor (b) `base: null` which results in `formatters.bindings()`
not being called by pino at all -- which broke addition of
"ecs.version", "service.name", and "event.dataset".