### PR TITLE
feat: separate winston ecsFormat to composable ecsFields and ecsStringify

### DIFF
--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- Add `ecsFields` and `ecsStringify` exports that are winston formatters
+  that separate the gathering of ECS fields (`ecsFields`) and the
+  stringification of a log record to an ecs-logging JSON object
+  (`ecsStringify`). This allows for better composability using
+  [`winston.format.combine`](https://github.com/winstonjs/logform#combine).
+  ([#65](https://github.com/elastic/ecs-logging-nodejs/pull/65))
+
+  The preferred way to import now changes. However, the old way is still
+  supported for backward compatibility.
+
+        const ecsFormat = require('@elastic/ecs-winston-format') // OLD
+        const { ecsFormat } = require('@elastic/ecs-winston-format') // NEW
+
+  Common usage will still use `ecsFormat` in the same way:
+
+        const { ecsFormat } = require('@elastic/ecs-winston-format')
+        const log = winston.createLogger({
+            format: ecsFormat(<options>),
+            // ...
+
+  However, one can use the separated formatters as follows:
+
+        const { ecsFields, ecsStringify } = require('@elastic/ecs-winston-format')
+        const log = winston.createLogger({
+            format: winston.format.combine(
+                ecsFields(<options>),
+                // Add a custom formatter to redact fields here.
+                ecsStringify()
+            ),
+            // ...
+
+  One good use case is for redaction of sensitive fields in the log record
+  as in [#57](https://github.com/elastic/ecs-logging-nodejs/issues/57).
+
 - Add `apmIntegration: false` option to all ecs-logging formatters to
   enable explicitly disabling Elastic APM integration.
   ([#62](https://github.com/elastic/ecs-logging-nodejs/pull/62))

--- a/loggers/winston/examples/redact-fields.js
+++ b/loggers/winston/examples/redact-fields.js
@@ -1,0 +1,123 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+const http = require('http')
+const fastRedact = require('fast-redact')
+const winston = require('winston')
+const { ecsFields, ecsStringify } = require('./') // @elastic/ecs-winston-format
+
+// A formatter for Winston loggers to redact (obscure or remove) log record
+// fields.
+//
+// Usage:
+//   const log = winston.createLogger({
+//     format: winston.format.combine(
+//       // ...
+//       new WinstonRedactFormatter(<options>),
+//       // Some finalizing formatter, for example:
+//       //     winston.format.json()
+//     ),
+//     // ...
+//   })
+//
+// For example, if your log records include HTTP request headers at
+// "http.request.headers" and your services uses auth, you might want to
+// redact the "Authorization" header via:
+//
+//       new WinstonRedactFormatter({
+//         paths: ['http.request.headers.authorization']
+//       })
+//
+// This will result in log records looking like:
+//
+//       "request": {
+//         "method": "GET",
+//         "headers": {
+//           "authorization": "[REDACTED]",
+//
+// Options:
+// - opts.paths: An array of strings describe the location of keys per
+//   https://github.com/davidmarkclements/fast-redact#paths--array
+// - opts.censor: The replacement value, by default "[REDACTED]".
+//   Tip: use `censor: undefined` to have matching paths replaced with
+//   `undefined` which, if you use a JSON log output format, will result in
+//   matching paths being *removed*.
+class WinstonRedactFormatter {
+  constructor (opts) {
+    const fastRedactOpts = {
+      paths: opts.paths,
+      // This option tells fast-redact to just do the redactions in-place.
+      // Leave serialization to a separate Winston formatter.
+      serialize: false
+    }
+    if ('censor' in opts) {
+      fastRedactOpts.censor = opts.censor
+    }
+    this.redact = fastRedact(fastRedactOpts)
+  }
+
+  transform (info) {
+    this.redact(info)
+    return info
+  }
+}
+
+const log = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    ecsFields({ convertReqRes: true }),
+    new WinstonRedactFormatter({
+      paths: ['passwd', 'http.request.headers.authorization']
+      // censor: '🙈'
+    }),
+    // Get *similar* results with winston.format.json().
+    ecsStringify()
+  ),
+  transports: [
+    new winston.transports.Console()
+  ]
+})
+
+const server = http.createServer(function handler (req, res) {
+  const body = JSON.stringify({ ping: 'pong' })
+  res.write(body)
+  res.end()
+  log.info('handled request', { req, res, passwd: 'sekrit' })
+})
+
+server.listen(3000, function () {
+  log.info('listening')
+  http.get('http://localhost:3000/', {
+    headers: {
+      Authorization: 'Bearer fuzzywuzzy'
+    }
+  }, function (res) {
+    const chunks = []
+    res.setEncoding('utf8')
+    res.on('data', function (c) {
+      chunks.push(c)
+    })
+    res.on('end', function () {
+      const body = chunks.join('')
+      log.info(`got ${res.statusCode} response`,
+        { headers: res.headers, body: body })
+      server.close()
+    })
+  })
+})

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -43,6 +43,7 @@
     "autocannon": "^7.0.1",
     "elastic-apm-node": "^3.10.0",
     "express": "^4.17.1",
+    "fast-redact": "^3.0.0",
     "split2": "^3.2.2",
     "standard": "16.x",
     "tap": "^14.x",

--- a/loggers/winston/test/basic.test.js
+++ b/loggers/winston/test/basic.test.js
@@ -26,7 +26,7 @@ const addFormats = require('ajv-formats').default
 const Ajv = require('ajv').default
 const { version } = require('@elastic/ecs-helpers')
 
-const ecsFormat = require('../')
+const { ecsFields, ecsFormat, ecsStringify } = require('../')
 const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
 
 const ajv = new Ajv({
@@ -59,6 +59,29 @@ test('Should produce valid ecs logs', t => {
   const cap = new CaptureTransport()
   const logger = winston.createLogger({
     format: ecsFormat(),
+    transports: [cap]
+  })
+  logger.info('ecs is cool!')
+  logger.error('ecs is cool!', { hello: 'world' })
+
+  cap.records.forEach((rec) => {
+    t.ok(validate(rec))
+  })
+  cap.infos.forEach((info) => {
+    t.equal(ecsLoggingValidate(info[MESSAGE]), null)
+  })
+  t.end()
+})
+
+test('basic test with separate ecsFields + ecsStringify', t => {
+  t.plan(4)
+
+  const cap = new CaptureTransport()
+  const logger = winston.createLogger({
+    format: winston.format.combine(
+      ecsFields(),
+      ecsStringify()
+    ),
     transports: [cap]
   })
   logger.info('ecs is cool!')


### PR DESCRIPTION
The current winston usage is a single ecsFormat formatter that handles
both (a) putting together the ECS fields and then (b) serializing that
to JSON (along with ecs-logging's preference for some serialized field
order).

    const log = winston.createLogger({
        format: ecsFormat(<options>),

Splitting these two steps into separate winston formatters allows for
some composability. For example, redacting sensitive info, as requested
in #57.

    const { ecsFields, ecsStringify } = require('@elastic/ecs-winston-format')
    const log = winston.createLogger({
        format: winston.format.combine(
            ecsFields(<options>),
            // Add a custom formatter to redact fields here.
            ecsStringify()
        ),

Fixes: #57


# TODO

- [x] get @lancegliser to try this out
- [x] changelog entry
- [x] tests for the new exports
- [ ] update asciidoc docs
- [ ] perhaps publish a winston-redact-format package with the example one created