### PR TITLE
fix(helpers): make formatHttpRequest and formatHttpResponse more defensive

### DIFF
--- a/helpers/CHANGELOG.md
+++ b/helpers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @elastic/ecs-helpers Changelog
 
+## Unreleased
+
+- Fix `formatHttpRequest` and `formatHttpResponse` to be more defensive. If
+  the given request or response object, respectively, is not one they know
+  how to process (for example if a user logs a `req` or `res` field that
+  is not a Node.js http request or response object), then processing is skipped.
+  The functions now return true if the given object could be processed,
+  false otherwise. `formatError` was similarly changed to return true/false for
+  whether the given `err` could be processed.
+
 ## v1.0.0
 
 - Change `formatHttpRequest` and `formatHttpResponse` to no longer exclude

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -46,10 +46,11 @@ of objects with circular references. This generally means that ecs-logging-nodej
 libraries will throw a "Converting circular structure to JSON" exception if an
 attempt is made to log an object with circular references.
 
-### `formatError(obj, err)`
+### `formatError(obj, err) -> bool`
 
 A function that adds [ECS Error fields](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)
-for a given `Error` object.
+for a given `Error` object. It returns true iff the given `err` was an Error
+object it could process.
 
 ```js
 const { formatError } = require('@elastic/ecs-helpers')
@@ -79,13 +80,18 @@ metadata field passed to a logging statement. E.g.
 `log.warn({err: myErr}, '...')` for pino, `log.warn('...', {err: myErr})`
 for winston.
 
-### `formatHttpRequest(obj, req)`
+### `formatHttpRequest(obj, req) -> bool`
 
 Function that enhances an ECS object with http request data.
 The given request object, `req`, must be one of the following:
 - Node.js's core [`http.IncomingMessage`](https://nodejs.org/api/all.html#http_class_http_incomingmessage),
 - [Express's request object](https://expressjs.com/en/5x/api.html#req) that extends IncomingMessage, or
 - a [hapi request object](https://hapi.dev/api/#request).
+
+The function returns true iff the given `req` was a request object it could
+process. Note that currently this notably does not process a
+[`http.ClientRequest`](https://nodejs.org/api/all.html#http_class_http_clientrequest)
+as returned from `http.request()`.
 
 ```js
 const http = require('http')
@@ -137,6 +143,13 @@ The given request object, `req`, must be one of the following:
 - Node.js's core [`http.ServerResponse`](https://nodejs.org/api/all.html#http_class_http_serverresponse),
 - [Express's response object](https://expressjs.com/en/5x/api.html#res) that extends ServerResponse, or
 - a [hapi **request** object](https://hapi.dev/api/#request)
+
+The function returns true iff the given `res` was a response object it could
+process. Note that currently this notably does not process a
+[`http.IncomingMessage`](https://nodejs.org/api/all.html#http_class_http_incomingmessage)
+that is the argument to the
+["response" event](https://nodejs.org/api/all.html#http_event_response) of a
+[client `http.request()`](https://nodejs.org/api/all.html#http_http_request_options_callback)
 
 ```js
 const http = require('http')

--- a/helpers/lib/error-formatters.js
+++ b/helpers/lib/error-formatters.js
@@ -21,10 +21,11 @@ const { toString } = Object.prototype
 
 // Format an Error instance into ECS-compatible fields on the `ecs` object.
 // https://www.elastic.co/guide/en/ecs/current/ecs-error.html
+// Return true iff the given `err` was an Error object that could be processed.
 function formatError (ecsFields, err) {
   if (!(err instanceof Error)) {
     ecsFields.err = err
-    return
+    return false
   }
 
   ecsFields.error = {
@@ -34,6 +35,8 @@ function formatError (ecsFields, err) {
     message: err.message,
     stack_trace: err.stack
   }
+
+  return true
 }
 
 module.exports = { formatError }

--- a/helpers/test/express.test.js
+++ b/helpers/test/express.test.js
@@ -38,8 +38,10 @@ test('express res/req serialization', t => {
     res.write('hi')
     res.end()
 
-    formatHttpRequest(rec, req)
-    formatHttpResponse(rec, res)
+    let rv = formatHttpRequest(rec, req)
+    t.ok(rv, 'formatHttpRequest processed req')
+    rv = formatHttpResponse(rec, res)
+    t.ok(rv, 'formatHttpResponse processed res')
 
     t.deepEqual(rec.user_agent, { original: 'cool-agent' })
     t.deepEqual(rec.url, {

--- a/helpers/test/hapi.test.js
+++ b/helpers/test/hapi.test.js
@@ -48,8 +48,10 @@ test('hapi res/req serialization', testOpts, t => {
 
   server.events.on('response', (request) => {
     const rec = {}
-    formatHttpRequest(rec, request)
-    formatHttpResponse(rec, request)
+    let rv = formatHttpRequest(rec, request)
+    t.ok(rv, 'formatHttpRequest processed request')
+    rv = formatHttpResponse(rec, request)
+    t.ok(rv, 'formatHttpResponse processed request')
 
     t.deepEqual(rec.user_agent, { original: 'cool-agent' })
     t.deepEqual(rec.url, {


### PR DESCRIPTION
This also changes those and formatError to return a bool for whether the
given obj was processed. The loggers will be able to use this to control
passing through an unprocessed special field.

Refs: #58