### PR TITLE
fix (pino): do not fallback to empty string "message" if none given

### DIFF
--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -1,17 +1,29 @@
 # @elastic/ecs-pino-format Changelog
 
+## Unreleased
+
+- The ecs-logging spec was [updated to allow "message" to be
+  optional](https://github.com/elastic/ecs-logging/pull/55). This allows the
+  [change to fallback to an empty string message](https://github.com/elastic/ecs-logging-nodejs/pull/64)
+  to be removed -- which is cleaner and fixes a
+  [side-effect bug](https://github.com/elastic/ecs-logging-nodejs/issues/73)
+  where usage of pino's `prettyPrint: true` was broken.
+
 ## v1.1.0
 
 - Fix a "TypeError: Cannot read property 'host' of undefined" crash when using
   `convertReqRes: true` and logging a `req` field that is not an HTTP request
   object.
+  ([#71](https://github.com/elastic/ecs-logging-nodejs/pull/71))
 
 - Set the "message" to the empty string for logger calls that provide no
   message, e.g. `log.info({foo: 'bar'})`. In this case pino will not add a
   message field, which breaks ecs-logging spec.
+  ([#64](https://github.com/elastic/ecs-logging-nodejs/pull/64))
 
 - Fix handling when the [`base`](https://getpino.io/#/docs/api?id=base-object)
   option is used to the pino constructor.
+  ([#63](https://github.com/elastic/ecs-logging-nodejs/pull/63))
 
   Before this change, using, for example:
         const log = pino({base: {foo: "bar"}, ...ecsFormat()})

--- a/loggers/pino/index.js
+++ b/loggers/pino/index.js
@@ -213,12 +213,6 @@ function createEcsPinoOptions (opts) {
           }
         }
 
-        // If no message (https://getpino.io/#/docs/api?id=message-string) is
-        // given in the log statement, then pino will not emit a message field.
-        // However, the ecs-logging spec requires a message field, so we set
-        // a fallback empty string.
-        ecsObj.message = ''
-
         return ecsObj
       }
     }

--- a/loggers/pino/test/basic.test.js
+++ b/loggers/pino/test/basic.test.js
@@ -133,7 +133,7 @@ test('ecsPinoFormat cases', suite => {
       }
     },
     {
-      name: 'no message in log call should result in empty string message',
+      name: 'no message in log call should be fine',
       pinoOpts: ecsFormat(),
       loggingFn: (log) => {
         log.info({ foo: 'bar' })
@@ -143,8 +143,7 @@ test('ecsPinoFormat cases', suite => {
         ecs: { version: ecsVersion },
         process: { pid: process.pid },
         host: { hostname: os.hostname },
-        foo: 'bar',
-        message: ''
+        foo: 'bar'
       }
     }
   ]


### PR DESCRIPTION
Now that "message" is optional in the ecs-logging spec, we can drop
the fallback to an empty string message added in #64.

Fixes: #73