### PR TITLE
feat: add internal/testing-only opts._elasticApm to facilitate APM agent tests

### DIFF
--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @elastic/ecs-pino-format Changelog
 
+## v1.2.0
+
+- Add an *internal testing-only* option (`opts._elasticApm`) to pass in the
+  current loaded "elastic-apm-node" module for use in APM tracing integration.
+  This option will be used by tests in the APM agent where the current agent
+  import name is a local path rather than "elastic-apm-node" that this code
+  normally uses.
+
 ## v1.1.2
 
 - Fix a circular-require for code that uses both this package and

--- a/loggers/pino/index.js
+++ b/loggers/pino/index.js
@@ -65,7 +65,12 @@ function createEcsPinoOptions (opts) {
   let apm = null
   let apmServiceName = null
   if (apmIntegration) {
-    if (!triedElasticApmImport) {
+    if (opts && opts._elasticApm) {
+      // `opts._elasticApm` is an internal/testing-only option to be used
+      // for testing in the APM agent where the import is a local path
+      // rather than "elastic-apm-node".
+      elasticApm = opts._elasticApm
+    } else if (!triedElasticApmImport) {
       triedElasticApmImport = true
       // We lazily require this module here instead of at the top-level to
       // avoid a possible circular-require if the user code does

--- a/loggers/pino/index.js
+++ b/loggers/pino/index.js
@@ -65,6 +65,7 @@ function createEcsPinoOptions (opts) {
   let apm = null
   let apmServiceName = null
   if (apmIntegration) {
+    // istanbul ignore if
     if (opts && opts._elasticApm) {
       // `opts._elasticApm` is an internal/testing-only option to be used
       // for testing in the APM agent where the import is a local path

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-pino-format",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Expected usage in APM agent tests is something like:

```
const apm = require('../..')  // note the import path is not "elastic-apm-node"
const log = pino(ecsFormat({ _elasticApm: apm }))
// ...
```

This allows the APM agent tests to use the local APM agent working copy to test APM tracing integration in the logger.
This is going to be used to test https://github.com/elastic/apm-agent-nodejs/pull/2127