### PR TITLE
@elastic/ecs-pino-format@1.3.0, @elastic/ecs-winston-format@1.3.0

### DIFF
--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/ecs-pino-format Changelog
 
+## v1.3.0
+
+- TypeScript types. ([#82](https://github.com/elastic/ecs-logging-nodejs/pull/82))
+
 ## v1.2.0
 
 - Add an *internal testing-only* option (`opts._elasticApm`) to pass in the

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@elastic/ecs-pino-format",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "types": "index.d.ts",
   "repository": {

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @elastic/ecs-winston-format Changelog
 
+## v1.3.0
+
+- TypeScript types. ([#88](https://github.com/elastic/ecs-logging-nodejs/pull/88))
+
 ## v1.1.0
 
 - Fix a crash ([#58](https://github.com/elastic/ecs-logging-nodejs/issues/58))

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
1.3.0 release of pino and winston to get TypeScript types released.