### PR TITLE
Fix TS import without esModuleInterop option

### DIFF
--- a/loggers/pino/index.d.ts
+++ b/loggers/pino/index.d.ts
@@ -29,4 +29,6 @@ interface Config {
 
 declare function createEcsPinoOptions(config?: Config): LoggerOptions;
 
+declare namespace createEcsPinoOptions {}
+
 export = createEcsPinoOptions;

--- a/loggers/winston/index.d.ts
+++ b/loggers/winston/index.d.ts
@@ -27,4 +27,8 @@ interface Config {
   apmIntegration?: boolean;
 }
 
-export = (opts?: Config) => Format
+declare function createEcsWinstonOptions(opts?: Config): Format;
+
+declare namespace createEcsWinstonOptions {}
+
+export = createEcsWinstonOptions;


### PR DESCRIPTION
Before this change and without esModuleInterop: true one could only import the module via

```js
import escFormat = require('@elastic/ecs-pino-format');
```

After this it can also be imported with: (which is more in-line with other such "interoperability" use cases)

```js
import * as escFormat from '@elastic/ecs-pino-format';
```

Refs: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html