### PR TITLE
fix(ecs-winston-format): fix expression in ambient context error

### DIFF
--- a/loggers/winston/index.d.ts
+++ b/loggers/winston/index.d.ts
@@ -1,4 +1,4 @@
-import type { Format } from "winston";
+import type { Logform } from "winston";
 
 interface Config {
   /**
@@ -27,4 +27,4 @@ interface Config {
   apmIntegration?: boolean;
 }
 
-export = (opts?: Config) => Format
+export default function(opts?: Config): Logform.Format;

--- a/loggers/winston/index.d.ts
+++ b/loggers/winston/index.d.ts
@@ -27,4 +27,6 @@ interface Config {
   apmIntegration?: boolean;
 }
 
-export default function(opts?: Config): Logform.Format;
+declare function ecsFormat(opts?: Config): Logform.Format;
+
+export = ecsFormat;


### PR DESCRIPTION
This commit fixes #92.