### PR TITLE
support multiple CommonJS, ESM, and TypeScript import styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ html_docs
 .DS_Store
 /tmp
 .vscode
+/loggers/pino/test/fixtures/ts-*/*.js

--- a/loggers/pino/index.d.ts
+++ b/loggers/pino/index.d.ts
@@ -27,6 +27,7 @@ interface Config {
   apmIntegration?: boolean;
 }
 
-declare function createEcsPinoOptions(config?: Config): LoggerOptions;
+declare function ecsFormat(config?: Config): LoggerOptions;
 
-export = createEcsPinoOptions;
+export default ecsFormat;
+export { ecsFormat }

--- a/loggers/pino/index.js
+++ b/loggers/pino/index.js
@@ -46,7 +46,7 @@ let elasticApm = null
 //        - "trace.id", "transaction.id", and "span.id" - if there is a current
 //          active trace when the log call is made
 //      Default true.
-function createEcsPinoOptions (opts) {
+function ecsFormat (opts) {
   let convertErr = true
   let convertReqRes = false
   let apmIntegration = true
@@ -252,4 +252,18 @@ function isVanillaObject (o) {
     (!o.constructor || o.constructor.name === 'Object'))
 }
 
-module.exports = createEcsPinoOptions
+// Exports to support the following import-styles from JS and TS code:
+// 1. `const { ecsFormat } = require('@elastic/ecs-pino-format)` in JS and TS.
+//    The preferred import style for JS code using CommonJS.
+// 2. `import { ecsFormat } from '@elastic/ecs-pino-format'` in JS and TS.
+//    ES module (ESM) import style. This is the preferred style for TypeScript
+//    code and for JS developers using ESM.
+// 3. `const ecsFormat = require('@elastic/ecs-pino-format')` in JS.
+//    The old, deprecated import method. Still supported for backward compat.
+// 4. `import ecsFormat from '@elastic/ecs-pino-format'` in JS and TS.
+//    This works, but is deprecated. Prefer #2 style.
+// 5. `import * as EcsPinoFormat from '@elastic/ecs-pino-format'` is TS.
+//    One must then use `EcsPinoFormat.ecsFormat()`.
+module.exports = ecsFormat // Required to support style 3.
+module.exports.ecsFormat = ecsFormat
+module.exports.default = ecsFormat // Required to support style 4.

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/elastic/ecs-logging-nodejs/blob/master/loggers/pino/README.md",
   "scripts": {
-    "test": "standard && tap --100 --timeout ${TAP_TIMEOUT:-10} test/*.test.js"
+    "test": "standard && tap --100 --timeout ${TAP_TIMEOUT:-40} test/*.test.js"
   },
   "engines": {
     "node": ">=10"
@@ -48,6 +48,12 @@
     "pino-http": "^5.3.0",
     "split2": "^3.1.1",
     "standard": "16.x",
-    "tap": "^14.x"
+    "tap": "^14.x",
+    "typescript": "^4.4.2"
+  },
+  "standard": {
+    "ignore": [
+      "/test/fixtures/ts-*/*.js"
+    ]
   }
 }

--- a/loggers/pino/test/fixtures/js-esm-import.mjs
+++ b/loggers/pino/test/fixtures/js-esm-import.mjs
@@ -1,0 +1,4 @@
+import { ecsFormat } from '../../index.js'
+import pino from 'pino'
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/js-require-default.js
+++ b/loggers/pino/test/fixtures/js-require-default.js
@@ -1,0 +1,5 @@
+// The old way to import @elastic/ecs-pino-format, support for backward compat.
+const ecsFormat = require('../../')
+const pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/js-require-destructuring.js
+++ b/loggers/pino/test/fixtures/js-require-destructuring.js
@@ -1,0 +1,5 @@
+// The new way to import @elastic/ecs-pino-format.
+const { ecsFormat } = require('../../')
+const pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/Makefile
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/Makefile
@@ -1,0 +1,7 @@
+# This is a convenience Makefile for quickly running the TS files in this
+# dir. It is not used by the test suite.
+.PHONY: all
+all:
+	rm -f *.js
+	tsc
+	ls *.js | while read f; do echo "# node $$f"; node $$f; done

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-default.ts
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-default.ts
@@ -1,0 +1,4 @@
+import ecsFormat from '../../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-destructuring.ts
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-destructuring.ts
@@ -1,0 +1,4 @@
+import { ecsFormat } from '../../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-star.ts
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/ts-import-star.ts
@@ -1,0 +1,4 @@
+import * as EcsPinoFormat from '../../../'
+import pino = require('pino')
+const log = pino(EcsPinoFormat.ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/ts-require.ts
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/ts-require.ts
@@ -1,0 +1,4 @@
+const { ecsFormat } = require('../../../')
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-esModuleInterop/tsconfig.json
+++ b/loggers/pino/test/fixtures/ts-esModuleInterop/tsconfig.json
@@ -1,0 +1,16 @@
+// Based on https://github.com/tsconfig/bases/blob/main/bases/node10.json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 10",
+
+  "compilerOptions": {
+    "lib": ["es2018"],
+    "module": "commonjs",
+    "target": "es2018",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/Makefile
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/Makefile
@@ -1,0 +1,7 @@
+# This is a convenience Makefile for quickly running the TS files in this
+# dir. It is not used by the test suite.
+.PHONY: all
+all:
+	rm -f *.js
+	tsc
+	ls *.js | while read f; do echo "# node $$f"; node $$f; done

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-default.ts
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-default.ts
@@ -1,0 +1,4 @@
+import ecsFormat from '../../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-destructuring.ts
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-destructuring.ts
@@ -1,0 +1,4 @@
+import { ecsFormat } from '../../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-star.ts
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-import-star.ts
@@ -1,0 +1,4 @@
+import * as EcsPinoFormat from '../../../'
+import pino = require('pino')
+const log = pino(EcsPinoFormat.ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-require.ts
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/ts-require.ts
@@ -1,0 +1,4 @@
+const { ecsFormat } = require('../../../')
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/loggers/pino/test/fixtures/ts-noEsModuleInterop/tsconfig.json
+++ b/loggers/pino/test/fixtures/ts-noEsModuleInterop/tsconfig.json
@@ -1,0 +1,16 @@
+// Based on https://github.com/tsconfig/bases/blob/main/bases/node10.json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 10",
+
+  "compilerOptions": {
+    "lib": ["es2018"],
+    "module": "commonjs",
+    "target": "es2018",
+
+    "strict": true,
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/loggers/pino/test/imports.test.js
+++ b/loggers/pino/test/imports.test.js
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+// Test all the supported import styles: for CommonJS, ESM, and TypeScript.
+// Each case is a JS or TS file in "test/fixtures/...".
+//
+// Note that we intentionally do NOT support the TypeScript-only
+// `import ecsFormat = require('...')` format
+// (https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
+
+const addFormats = require('ajv-formats').default
+const Ajv = require('ajv').default
+const { execFile, execSync } = require('child_process')
+const path = require('path')
+const test = require('tap').test
+
+const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
+
+const ajv = new Ajv({
+  allErrors: true,
+  verbose: true
+})
+addFormats(ajv)
+const validate = ajv.compile(require('../../../utils/schema.json'))
+
+test('import cases', suite => {
+  const importCases = [
+    { file: 'fixtures/js-require-default.js' },
+    { file: 'fixtures/js-require-destructuring.js' },
+    { file: 'fixtures/js-esm-import.mjs' },
+    // TypeScript using esModuleInterop:true (the default setting from
+    // `tsc --init`).
+    {
+      file: 'fixtures/ts-esModuleInterop/ts-import-default.js',
+      build: 'pwd && ls && cd fixtures/ts-esModuleInterop && npx tsc ts-import-default.ts'
+    },
+    {
+      file: 'fixtures/ts-esModuleInterop/ts-import-destructuring.js',
+      build: 'pwd && ls && cd fixtures/ts-esModuleInterop && npx tsc ts-import-destructuring.ts'
+    },
+    {
+      file: 'fixtures/ts-esModuleInterop/ts-import-star.js',
+      build: 'pwd && ls && cd fixtures/ts-esModuleInterop && npx tsc ts-import-star.ts'
+    },
+    {
+      file: 'fixtures/ts-esModuleInterop/ts-require.js',
+      build: 'pwd && ls && cd fixtures/ts-esModuleInterop && npx tsc ts-require.ts'
+    },
+    // TypeScript using esModuleInterop:false.
+    {
+      file: 'fixtures/ts-noEsModuleInterop/ts-import-default.js',
+      build: 'pwd && ls && cd fixtures/ts-noEsModuleInterop && npx tsc ts-import-default.ts'
+    },
+    {
+      file: 'fixtures/ts-noEsModuleInterop/ts-import-destructuring.js',
+      build: 'pwd && ls && cd fixtures/ts-noEsModuleInterop && npx tsc ts-import-destructuring.ts'
+    },
+    {
+      file: 'fixtures/ts-noEsModuleInterop/ts-import-star.js',
+      build: 'pwd && ls && cd fixtures/ts-noEsModuleInterop && npx tsc ts-import-star.ts'
+    },
+    {
+      file: 'fixtures/ts-noEsModuleInterop/ts-require.js',
+      build: 'pwd && ls && cd fixtures/ts-noEsModuleInterop && npx tsc ts-require.ts'
+    }
+  ]
+
+  importCases.forEach((ic) => {
+    suite.test('import case: ' + ic.file, t => {
+      if (ic.build) {
+        execSync(ic.build, {
+          cwd: __dirname,
+          timeout: 5000
+        })
+      }
+
+      execFile(
+        process.execPath,
+        [path.join(__dirname, ic.file)],
+        { timeout: 5000 },
+        function (err, stdout, stderr) {
+          t.error(err)
+          const rec = JSON.parse(stdout)
+          t.ok(rec, 'got a single log record')
+          t.equal(rec.message, 'hi', 'log message is "hi"')
+          t.ok(validate(rec))
+          t.equal(ecsLoggingValidate(stdout, { ignoreIndex: true }), null)
+          t.end()
+        }
+      )
+    })
+  })
+
+  suite.end()
+})


### PR DESCRIPTION
Support these import styles:

```js
// 1. `const { ecsFormat } = require('@elastic/ecs-pino-format)` in JS and TS.
//    The preferred import style for JS code using CommonJS.
// 2. `import { ecsFormat } from '@elastic/ecs-pino-format'` in JS and TS.
//    ES module (ESM) import style. This is the preferred style for TypeScript
//    code and for JS developers using ESM.
// 3. `const ecsFormat = require('@elastic/ecs-pino-format')` in JS.
//    The old, deprecated import method. Still supported for backward compat.
// 4. `import ecsFormat from '@elastic/ecs-pino-format'` in JS and TS.
//    This works, but is deprecated. Prefer #2 style.
// 5. `import * as EcsPinoFormat from '@elastic/ecs-pino-format'` is TS.
//    One must then use `EcsPinoFormat.ecsFormat()`
```

Note that this *excludes* support for the [TypeScript-only "import = require" style](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require):

```js
import ecsFormat = require('@elastic/ecs-pino-format') 
```

Note that for TypeScript users I think this may be a breaking change. FWIW that TypeScript was only added in the last release (v1.3.0) and was the original intent was more for adding VSCode completion support than about TypeScript code integration.

### current status

Just ecs-pino-format so far. If this seems good, I'll do it for winston and morgan as well.

- [x] ecs-pino-format
- [ ] some sanity check and review
- [ ] ecs-winston-format
- [ ] ecs-morgan-format
- [ ] update preferred import style in docs and examples and tests
- [ ] changelog entry