### PR TITLE
@elastic/ecs-winston-format@1.3.1

### DIFF
--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @elastic/ecs-winston-format Changelog
 
+## v1.3.1
+
+- Fix types expression in ambient context error.
+  ([#93](https://github.com/elastic/ecs-logging-nodejs/pull/93))
+
 ## v1.3.0
 
 - TypeScript types. ([#88](https://github.com/elastic/ecs-logging-nodejs/pull/88))

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
A release to get https://github.com/elastic/ecs-logging-nodejs/pull/93 out.