### PR TITLE
Add a link to the Node.js ECS logging tutorial in the Cloud docs

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -29,3 +29,5 @@ Ready to jump into Node.js ECS logging?
 - <<morgan,ECS Logging with Morgan>>
 - <<pino,ECS Logging with Pino>>
 - <<winston,ECS Logging with Winston>>
+
+If you'd like to try out a tutorial using Node.js ECS logging with winston, see {cloud}/ec-getting-started-search-use-cases-node-logs.html[Ingest logs from a Node.js web application using Filebeat].


### PR DESCRIPTION
This adds a link to a new [Node.JS ECS logging tutorial](https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-node-logs.html) in the Cloud docs.

@bmorelli25, or anyone, please let me know if you think there might be a better place for this link.