### PR TITLE
Add a link from winston ECS logging to a Cloud tutorial doc

### DIFF
--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -265,3 +265,5 @@ const logger = winston.createLogger({
   // ...
 })
 ----
+
+To learn more, try out our tutorial using Node.js ECS logging with winston: {cloud}/ec-getting-started-search-use-cases-node-logs.html[Ingest logs from a Node.js web application using Filebeat].

--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -50,6 +50,7 @@ The best way to collect the logs once they are ECS-formatted is with {filebeat-r
 
 include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]
 
+NOTE: You might like to try out our tutorial using Node.js ECS logging with winston: {cloud}/ec-getting-started-search-use-cases-node-logs.html[Ingest logs from a Node.js web application using Filebeat].
 
 [float]
 [[winston-usage]]
@@ -266,4 +267,3 @@ const logger = winston.createLogger({
 })
 ----
 
-To learn more, try out our tutorial using Node.js ECS logging with winston: {cloud}/ec-getting-started-search-use-cases-node-logs.html[Ingest logs from a Node.js web application using Filebeat].


### PR DESCRIPTION
Rel: #99 
Adds a link at the bottom of this [Node.js winston ECS logging page](https://www.elastic.co/guide/en/ecs-logging/nodejs/master/winston.html#_setup_3) to a [similar tutorial](https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-node-logs.html) in the Cloud docs.