### PR TITLE
tests: update APM-related tests for zero-conf and run-context changes

### DIFF
--- a/loggers/pino/test/apm.test.js
+++ b/loggers/pino/test/apm.test.js
@@ -368,15 +368,12 @@ test('can override service.name, event.dataset in base arg to constructor', t =>
   })
 })
 
-test('unset APM serviceName does not set service.name, event.dataset, but also does not break', t => {
+test('invalid APM serviceName does not set service.name or event.dataset, but also does not break', t => {
   execFile(process.execPath, [
-    path.join(__dirname, 'use-apm-override-service-name.js')
-    // Leave <serviceName> arg empty.
+    path.join(__dirname, 'use-apm-override-service-name.js'),
+    'foo☃bar' // Use an invalid <serviceName>.
   ], {
-    timeout: 5000,
-    // Ensure the APM Agent's auto-configuration of `serviceName`, via looking
-    // up dirs for a package.json, does *not* work by execing from the root dir.
-    cwd: '/'
+    timeout: 5000
   }, function (err, stdout, stderr) {
     t.error(err)
     const recs = stdout.trim().split(/\n/g).map(JSON.parse)

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -53,9 +53,9 @@ const server = http.createServer()
 server.once('request', function handler (req, res) {
   const span = apm.startSpan('auth')
   setImmediate(function doneAuth () {
-    span.end()
     res.end('ok')
     log.info({ req, res }, 'handled request')
+    span.end()
     server.close()
   })
 })

--- a/loggers/winston/index.js
+++ b/loggers/winston/index.js
@@ -107,12 +107,10 @@ function ecsTransform (info, opts) {
       ? ecsFields.service.name
       : undefined)
     if (!serviceName) {
-      // https://github.com/elastic/apm-agent-nodejs/pull/1949 is adding
-      // getServiceName() in v3.11.0. Fallback to private `apm._conf`.
       // istanbul ignore next
       serviceName = apm.getServiceName
-        ? apm.getServiceName()
-        : apm._conf.serviceName
+        ? apm.getServiceName() // added in elastic-apm-node@3.11.0
+        : apm._conf.serviceName // fallback to private `_conf`
       // A mis-configured APM Agent can be "started" but not have a
       // "serviceName".
       if (serviceName) {

--- a/loggers/winston/test/apm.test.js
+++ b/loggers/winston/test/apm.test.js
@@ -353,15 +353,12 @@ test('can override service.name, event.dataset', t => {
   })
 })
 
-test('unset APM serviceName does not set service.name, event.dataset, but also does not break', t => {
+test('invalid APM serviceName does not set service.name or event.dataset, but also does not break', t => {
   execFile(process.execPath, [
-    path.join(__dirname, 'use-apm-override-service-name.js')
-    // Leave <serviceName> arg empty.
+    path.join(__dirname, 'use-apm-override-service-name.js'),
+    'foo☃bar' // Use an invalid <serviceName>.
   ], {
-    timeout: 5000,
-    // Ensure the APM Agent's auto-configuration of `serviceName`, via looking
-    // up dirs for a package.json, does *not* work by execing from the root dir.
-    cwd: '/'
+    timeout: 5000
   }, function (err, stdout, stderr) {
     t.error(err)
     const recs = stdout.trim().split(/\n/g).map(JSON.parse)

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -59,9 +59,9 @@ const server = http.createServer()
 server.once('request', function handler (req, res) {
   const span = apm.startSpan('auth')
   setImmediate(function doneAuth () {
-    span.end()
     res.end('ok')
     log.info('handled request', { req, res })
+    span.end()
     server.close()
   })
 })


### PR DESCRIPTION
Two changes in elastic-apm-node@3.24.0 impacted tests here:
- "Zero configuration support" changed how the APM serviceName is
  handled for edge cases.
- Run context handling changes made it so `span.end()` actually removes
  the span from the current context, so log records after span.end() no
  longer have that span.id.