### PR TITLE
tests: fix apm-integration tests failures due to newer agent making APM server version check

### DIFF
--- a/loggers/morgan/test/serve-one-http-req-with-apm.js
+++ b/loggers/morgan/test/serve-one-http-req-with-apm.js
@@ -36,7 +36,8 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0
+  metricsInterval: 0,
+  apmServerVersion: '8.2.0' // avoid APM server version check request
 })
 
 const app = require('express')()

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -35,7 +35,8 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0
+  metricsInterval: 0,
+  apmServerVersion: '8.2.0' // avoid APM server version check request
 })
 
 const http = require('http')

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -35,7 +35,8 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0
+  metricsInterval: 0,
+  apmServerVersion: '8.2.0' // avoid APM server version check request
 })
 
 const http = require('http')


### PR DESCRIPTION
In elastic-apm-node@3.28.0 (https://github.com/elastic/apm-agent-nodejs/pull/2546)
the APM agent added a default request to "GET /" of the APM server to
determine its version. This broke tests here.


This fixes test failures such as these ones:
https://apm-ci.elastic.co/job/apm-agent-nodejs/job/ecs-logging-nodejs-mbp/job/main/5/

```
13:47:54  > @elastic/ecs-winston-format@1.3.1 test /var/lib/jenkins/workspace/dejs_ecs-logging-nodejs-mbp_main/src/go.elastic.co/apm/ecs-logging-nodejs/loggers/winston
13:47:54  > standard && tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js
13:47:54  
13:47:57  TAP version 13
13:52:57  # Subtest: test/apm.test.js
13:52:57      # Subtest: tracing integration works
13:52:57          ok 1 - no error from starting the mock APM server
13:52:57          ok 2 - apmServerUrl: http://localhost:43605/
13:52:57          ok 3 - should be equal
13:52:57          ok 4 - first listening log line has "address"
13:52:57          ok 5 - no error from starting the app
13:52:57          ok 6 - appUrl: http://localhost:44981/
13:52:57          not ok 7 - should be equal
13:52:57            ---
13:52:57            compare: ===
13:52:57            at:
13:52:57              line: 53
13:52:57              column: 9
13:52:57              file: test/apm.test.js
13:52:57              type: Server
13:52:57              function: apmServerReq
13:52:57            stack: |
13:52:57              Server.apmServerReq (test/apm.test.js:53:9)
13:52:57            source: |2
13:52:57                  apmServer = http.createServer(function apmServerReq (req, res) {
13:52:57                    t.equal(req.method, 'POST')
13:52:57              --------^
13:52:57                    t.equal(req.url, '/intake/v2/events')
13:52:57                    let instream = req
13:52:57            diff: |
13:52:57              --- expected
13:52:57              +++ actual
13:52:57              @@ -1,1 +1,1 @@
13:52:57              -POST
13:52:57              +GET
13:52:57            ...
...
```