### PR TITLE
action: use opentelemetry composite action

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,18 @@
+---
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows:
+      - test
+    types: [completed]
+
+jobs:
+  otel-export-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Motivation/summary

Back in the days we built the Jenkins OTEL integration, so let's use the same approach for the GH actions, so every workflow and step will be tracked as traces/spans.


## How to test these changes

See traces in the Elastic deployment

This has been already tested for quite sometime in some other projects


<img width="1845" alt="image" src="https://user-images.githubusercontent.com/2871786/212675487-e9fc2937-edbd-4d66-925f-a474e82a966c.png">


https://github.com/elastic/apm-pipeline-library/blob/main/.github/workflows/opentelemetry.yml