### PR TITLE
bump up fast-json-stringify to stop using deprecated string-similarity

### DIFF
--- a/helpers/package.json
+++ b/helpers/package.json
@@ -23,7 +23,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "fast-json-stringify": "^5.0.6"
+    "fast-json-stringify": "5.0.6"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.1.0",

--- a/helpers/package.json
+++ b/helpers/package.json
@@ -23,7 +23,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "fast-json-stringify": "^2.4.1"
+    "fast-json-stringify": "^5.0.6"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.1.0",


### PR DESCRIPTION
### What
Upgrade fast-json-stringify from v2.4.1 to v5.5.0

### Why
**@elastic/ecs-pino-format** depends on **@elastic/ecs-helpers**, which depends on an old version of **fast-json-stringify**, which depends on **string-similarity** which is [deprecated](https://www.npmjs.com/package/string-similarity).

since v5.0 of **fast-json-stringify**, it does not depend on **string-similarity** anymore.

_Changeset_
- [elastic/ecs-logging-nodejs@eceb20d](https://github.com/elastic/ecs-logging-nodejs/commit/eceb20d3904ca9bcbbd2e5e471c0678c2f553646) 