### PR TITLE
tests: fix tests to work with recent elastic-apm-node that includes a log preamble

### DIFF
--- a/loggers/morgan/test/serve-one-http-req-with-apm.js
+++ b/loggers/morgan/test/serve-one-http-req-with-apm.js
@@ -36,8 +36,9 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0,
-  apmServerVersion: '8.2.0' // avoid APM server version check request
+  metricsInterval: '0s',
+  apmServerVersion: '8.9.0', // avoid APM server version check request
+  logLevel: 'warn' // avoid APM agent log preamble
 })
 
 const app = require('express')()

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -35,8 +35,9 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0,
-  apmServerVersion: '8.2.0' // avoid APM server version check request
+  metricsInterval: '0s',
+  apmServerVersion: '8.9.0', // avoid APM server version check request
+  logLevel: 'warn' // avoid APM agent log preamble
 })
 
 const http = require('http')

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -35,8 +35,9 @@ const apm = require('elastic-apm-node').start({
   serviceName: 'test-apm',
   centralConfig: false,
   captureExceptions: false,
-  metricsInterval: 0,
-  apmServerVersion: '8.2.0' // avoid APM server version check request
+  metricsInterval: '0s',
+  apmServerVersion: '8.9.0', // avoid APM server version check request
+  logLevel: 'warn' // avoid APM agent log preamble
 })
 
 const http = require('http')


### PR DESCRIPTION
Since elastic-apm-node@3.47.0 the APM agent will log.info a preamble with config and some other basic debugging info. This was breaking the APM-related tests.