### PR TITLE
fix: update remaining cases where `ecs.version` was not a top-level field

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -32,9 +32,7 @@ const ecs = {
   log: {
     logger: 'test'
   },
-  ecs: {
-    version: '1.4.0'
-  }
+  'ecs.version': '1.4.0'
 }
 
 console.log(stringify(ecs))

--- a/helpers/test/basic.test.js
+++ b/helpers/test/basic.test.js
@@ -47,9 +47,7 @@ test('stringify should return a valid ecs json', t => {
     '@timestamp': new Date().toISOString(),
     'log.level': 'info',
     message: 'hello world',
-    ecs: {
-      version: '1.4.0'
-    }
+    'ecs.version': '1.4.0'
   }
 
   const line = stringify(ecsFields)
@@ -64,9 +62,7 @@ test('bad ECS json on purpose: @timestamp', t => {
     '@timestamp': 'not a date',
     'log.level': 'info',
     message: 'foo',
-    ecs: {
-      version: '1.4.0'
-    }
+    'ecs.version': '1.4.0'
   }
 
   const line = stringify(ecsFields)
@@ -133,9 +129,7 @@ test('formatHttpRequest and formatHttpResponse should return a valid ecs object'
       '@timestamp': new Date().toISOString(),
       'log.level': 'info',
       message: 'hello world',
-      ecs: {
-        version: '1.4.0'
-      }
+      'ecs.version': '1.4.0'
     }
 
     const resBody = 'ok'
@@ -235,9 +229,7 @@ test('stringify should emit valid tracing fields', t => {
     '@timestamp': new Date().toISOString(),
     'log.level': 'info',
     message: 'hello world',
-    ecs: {
-      version: '1.4.0'
-    },
+    'ecs.version': '1.4.0',
     trace: { id: 1 },
     transaction: { id: 2 },
     span: { id: 3, extra_fields: 'are dropped' }

--- a/loggers/pino/README.md
+++ b/loggers/pino/README.md
@@ -38,8 +38,8 @@ child.warn('From child')
 Running this will produce log output similar to the following:
 
 ```sh
-{"log.level":"info","@timestamp":"2021-01-19T22:51:12.142Z","ecs":{"version":"1.6.0"},"process":{"pid":82240},"host":{"hostname":"pink.local"},"message":"Hello world"}
-{"log.level":"warn","@timestamp":"2021-01-19T22:51:12.143Z","ecs":{"version":"1.6.0"},"process":{"pid":82240},"host":{"hostname":"pink.local"},"module":"foo","message":"From child"}
+{"log.level":"info","@timestamp":"2023-10-16T18:08:02.601Z","process.pid":74325,"host.hostname":"pink.local","ecs.version":"1.6.0","message":"Hello world"}
+{"log.level":"warn","@timestamp":"2023-10-16T18:08:02.602Z","process.pid":74325,"host.hostname":"pink.local","ecs.version":"1.6.0","module":"foo","message":"From child"}
 ```
 
 Please see the [Node.js ECS pino documentation](https://www.elastic.co/guide/en/ecs-logging/nodejs/current/pino.html) for more.


### PR DESCRIPTION
Changes in #150 missed these. Then the subsequent spec update (#135)
resulted in tests being broken by those missing cases.
