### PR TITLE
feat: more correlation fields: service.version, service.environment, service.node.name

### DIFF
--- a/docs/morgan.asciidoc
+++ b/docs/morgan.asciidoc
@@ -32,7 +32,7 @@ const app = require('express')()
 const morgan = require('morgan')
 const ecsFormat = require('@elastic/ecs-morgan-format')
 
-app.use(morgan(ecsFormat())) <1>
+app.use(morgan(ecsFormat(/* options */))) <1>
 
 // ...
 app.get('/', function (req, res) {
@@ -62,7 +62,7 @@ const app = require('express')()
 const morgan = require('morgan')
 const ecsFormat = require('@elastic/ecs-morgan-format')
 
-app.use(morgan(ecsFormat()))
+app.use(morgan(ecsFormat(/* options */))) <1>
 
 app.get('/', function (req, res) {
   res.send('hello, world!')
@@ -73,6 +73,7 @@ app.get('/error', function (req, res, next) {
 
 app.listen(3000)
 ----
+<1> See available options <<morgan-ref,below>>.
 
 Running this script (the full example is https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/morgan/examples/express.js[here])
 and making a request (via `curl -i localhost:3000/`) will produce log output
@@ -161,14 +162,21 @@ again, a `curl -i localhost:3000/error` will yield:
 
 [float]
 [[morgan-apm]]
-=== Integration with APM Tracing
+=== Log Correlation with APM
 
-This ECS log formatter integrates with https://www.elastic.co/apm[Elastic APM] tracing.
+This ECS log formatter integrates with https://www.elastic.co/apm[Elastic APM].
 If your Node app is using the {apm-node-ref}/intro.html[Node.js Elastic APM Agent],
-then fields are added to log records that {ecs-ref}/ecs-tracing.html[identify an active trace] and the configured service name
-({ecs-ref}/ecs-service.html["service.name"] and {ecs-ref}/ecs-event.html["event.dataset"]).
-These fields allow cross linking between traces and logs in Kibana and support
-log anomaly detection.
+then a number of fields are added to log records to correlate between APM
+services or traces and logging data:
+
+- Log statements (e.g. `logger.info(...)`) called when there is a current
+  tracing span will include {ecs-ref}/ecs-tracing.html[tracing fields] --
+  `trace.id`, `transaction.id`.
+- A number of service identifier fields determined by or configured on the APM
+  agent allow cross-linking between services and logs in Kibana --
+  `service.name`, `service.version`, `service.environment`, `service.node.name`.
+- `event.dataset` enables {observability-guide}/inspect-log-anomalies.html[log
+  rate anomaly detection] in the Elastic Observability app.
 
 For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/morgan/examples/express-with-apm.js[examples/express-with-apm.js] and `curl -i localhost:3000/` results in a log record with the following:
 
@@ -177,10 +185,12 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/log
 % node examples/express-with-apm.js | jq .
 {
   // The same fields as before, plus:
-  "trace.id": "e097193afa9ac221017b45a1f674601c",
-  "transaction.id": "c6aa5b47e01bad72",
   "service.name": "express-with-elastic-apm",
-  "event.dataset": "express-with-elastic-apm"
+  "service.version": "1.1.0",
+  "service.environment": "development",
+  "event.dataset": "express-with-elastic-apm",
+  "trace.id": "116d46f667a7600deed9c41fa015f7de",
+  "transaction.id": "b84fb72d7bf42866"
 }
 ----
 
@@ -193,3 +203,24 @@ Integration with Elastic APM can be explicitly disabled via the
 ----
 app.use(morgan(ecsFormat({ apmIntegration: false })))
 ----
+
+
+[float]
+[[morgan-ref]]
+=== Reference
+
+[float]
+[[morgan-ref-ecsFormat]]
+==== `ecsFormat([options])`
+
+* `options` +{type-object}+ The following options are supported:
+** `format` +{type-string}+ A format *name* (e.g. 'combined'), format function (e.g. `morgan.combined`), or a format string (e.g. ':method :url :status'). This is used to format the "message" field. Defaults to `morgan.combined`.
+** `convertErr` +{type-boolean}+ Whether to convert a logged `err` field to ECS error fields. *Default:* `true`.
+** `apmIntegration` +{type-boolean}+ Whether to enable APM agent integration. *Default:* `true`.
+** `serviceName` +{type-string}+ A "service.name" value. If specified this overrides any value from an active APM agent.
+** `serviceVersion` +{type-string}+ A "service.version" value. If specified this overrides any value from an active APM agent.
+** `serviceEnvironment` +{type-string}+ A "service.environment" value. If specified this overrides any value from an active APM agent.
+** `serviceNodeName` +{type-string}+ A "service.node.name" value. If specified this overrides any value from an active APM agent.
+** `eventDataset` +{type-string}+ A "event.dataset" value. If specified this overrides the default of using `${serviceVersion}`.
+
+Create a formatter for morgan that emits in ECS Logging format.

--- a/docs/pino.asciidoc
+++ b/docs/pino.asciidoc
@@ -29,7 +29,7 @@ $ npm install @elastic/ecs-pino-format
 const ecsFormat = require('@elastic/ecs-pino-format')
 const pino = require('pino')
 
-const log = pino(ecsFormat()) <1>
+const log = pino(ecsFormat(/* options */)) <1>
 log.info('hi')
 log.error({ err: new Error('boom') }, 'oops there is a problem')
 // ...
@@ -56,13 +56,13 @@ include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]
 const ecsFormat = require('@elastic/ecs-pino-format')
 const pino = require('pino')
 
-const log = pino(ecsFormat()) <1>
+const log = pino(ecsFormat(/* options */)) <1>
 log.info('Hello world')
 
 const child = log.child({ module: 'foo' })
 child.warn('From child')
 ----
-
+<1> See available options <<pino-ref,below>>.
 
 Running this will produce log output similar to the following:
 
@@ -205,14 +205,21 @@ etc.
 
 [float]
 [[pino-apm]]
-=== Integration with APM Tracing
+=== Log Correlation with APM
 
 This ECS log formatter integrates with https://www.elastic.co/apm[Elastic APM].
 If your Node app is using the {apm-node-ref}/intro.html[Node.js Elastic APM Agent],
-then fields are added to log records that {ecs-ref}/ecs-tracing.html[identify an active trace] and the configured service name
-({ecs-ref}/ecs-service.html["service.name"] and {ecs-ref}/ecs-event.html["event.dataset"]).
-These fields allow cross linking between traces and logs in Kibana and support
-log anomaly detection.
+then a number of fields are added to log records to correlate between APM
+services or traces and logging data:
+
+- Log statements (e.g. `logger.info(...)`) called when there is a current
+  tracing span will include {ecs-ref}/ecs-tracing.html[tracing fields] --
+  `trace.id`, `transaction.id`, `span.id`.
+- A number of service identifier fields determined by or configured on the APM
+  agent allow cross-linking between services and logs in Kibana --
+  `service.name`, `service.version`, `service.environment`, `service.node.name`.
+- `event.dataset` enables {observability-guide}/inspect-log-anomalies.html[log
+  rate anomaly detection] in the Elastic Observability app.
 
 For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/pino/examples/http-with-elastic-apm.js[examples/http-with-elastic-apm.js] and `curl -i localhost:3000/` results in a log record with the following:
 
@@ -221,9 +228,11 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/log
 % node examples/http-with-elastic-apm.js | jq .
 ...
   "service.name": "http-with-elastic-apm",
+  "service.version": "1.4.0",
+  "service.environment": "development",
   "event.dataset": "http-with-elastic-apm",
-  "trace.id": "79de6da334efae17ad43758573d57f1c",
-  "transaction.id": "8bf944f94b72c54d",
+  "trace.id": "9f338eae7211b7993b98929046aed21d",
+  "transaction.id": "2afbef5642cc7a3f",
 ...
 ----
 
@@ -254,3 +263,24 @@ fields passed to `<logger>.child({ ... })`. This means that, even with the
 `convertReqRes` option, a call to `<logger>.child({ req })` will *not* convert
 that `req` to ECS HTTP fields. This is a slight limitation for users of
 https://github.com/pinojs/pino-http[pino-http] which does this.
+
+
+[float]
+[[pino-ref]]
+=== Reference
+
+[float]
+[[pino-ref-ecsFormat]]
+==== `ecsFormat([options])`
+
+* `options` +{type-object}+ The following options are supported:
+** `convertErr` +{type-boolean}+ Whether to convert a logged `err` field to ECS error fields. *Default:* `true`.
+** `convertReqRes` +{type-boolean}+ Whether to logged `req` and `res` HTTP request and response fields to ECS HTTP, User agent, and URL fields. *Default:* `false`.
+** `apmIntegration` +{type-boolean}+ Whether to enable APM agent integration. *Default:* `true`.
+** `serviceName` +{type-string}+ A "service.name" value. If specified this overrides any value from an active APM agent.
+** `serviceVersion` +{type-string}+ A "service.version" value. If specified this overrides any value from an active APM agent.
+** `serviceEnvironment` +{type-string}+ A "service.environment" value. If specified this overrides any value from an active APM agent.
+** `serviceNodeName` +{type-string}+ A "service.node.name" value. If specified this overrides any value from an active APM agent.
+** `eventDataset` +{type-string}+ A "event.dataset" value. If specified this overrides the default of using `${serviceVersion}`.
+
+Create options for `pino(...)` that configures ECS Logging format output.

--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -30,7 +30,7 @@ const winston = require('winston')
 const ecsFormat = require('@elastic/ecs-winston-format')
 
 const logger = winston.createLogger({
-  format: ecsFormat(), <1>
+  format: ecsFormat(/* options */), <1>
   transports: [
     new winston.transports.Console()
   ]
@@ -63,7 +63,7 @@ const ecsFormat = require('@elastic/ecs-winston-format')
 
 const logger = winston.createLogger({
   level: 'info',
-  format: ecsFormat(), <1>
+  format: ecsFormat(/* options */), <1>
   transports: [
     new winston.transports.Console()
   ]
@@ -72,6 +72,7 @@ const logger = winston.createLogger({
 logger.info('hi')
 logger.error('oops there is a problem', { foo: 'bar' })
 ----
+<1> See available options <<winston-ref,below>>.
 
 Running this script (available https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/winston/examples/basic.js[here]) will produce log output similar to the following:
 
@@ -226,14 +227,21 @@ For https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/winston/exam
 
 [float]
 [[winston-apm]]
-=== Integration with APM Tracing
+=== Log Correlation with APM
 
 This ECS log formatter integrates with https://www.elastic.co/apm[Elastic APM].
 If your Node app is using the {apm-node-ref}/intro.html[Node.js Elastic APM Agent],
-then fields are added to log records that {ecs-ref}/ecs-tracing.html[identify an active trace] and the configured service name
-({ecs-ref}/ecs-service.html["service.name"] and {ecs-ref}/ecs-event.html["event.dataset"]).
-These fields allow cross linking between traces and logs in Kibana and support
-log anomaly detection.
+then a number of fields are added to log records to correlate between APM
+services or traces and logging data:
+
+- Log statements (e.g. `logger.info(...)`) called when there is a current
+  tracing span will include {ecs-ref}/ecs-tracing.html[tracing fields] --
+  `trace.id`, `transaction.id`, `span.id`.
+- A number of service identifier fields determined by or configured on the APM
+  agent allow cross-linking between services and logs in Kibana --
+  `service.name`, `service.version`, `service.environment`, `service.node.name`.
+- `event.dataset` enables {observability-guide}/inspect-log-anomalies.html[log
+  rate anomaly detection] in the Elastic Observability app.
 
 For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/winston/examples/http-with-elastic-apm.js[examples/http-with-elastic-apm.js] and `curl -i localhost:3000/` results in a log record with the following:
 
@@ -242,7 +250,9 @@ For example, running https://github.com/elastic/ecs-logging-nodejs/blob/main/log
 % node examples/http-with-elastic-apm.js | jq .
 ...
   "service.name": "http-with-elastic-apm",
-  "event.dataset": "http-with-elastic-apm",
+  "service.version": "1.4.0",
+  "service.environment": "development",
+  "event.dataset": "http-with-elastic-apm"
   "trace.id": "7fd75f0f33ff49aba85d060b46dcad7e",
   "transaction.id": "6c97c7c1b468fa05"
 }
@@ -261,3 +271,22 @@ const logger = winston.createLogger({
 })
 ----
 
+[float]
+[[winston-ref]]
+=== Reference
+
+[float]
+[[winston-ref-ecsFormat]]
+==== `ecsFormat([options])`
+
+* `options` +{type-object}+ The following options are supported:
+** `convertErr` +{type-boolean}+ Whether to convert a logged `err` field to ECS error fields. *Default:* `true`.
+** `convertReqRes` +{type-boolean}+ Whether to logged `req` and `res` HTTP request and response fields to ECS HTTP, User agent, and URL fields. *Default:* `false`.
+** `apmIntegration` +{type-boolean}+ Whether to enable APM agent integration. *Default:* `true`.
+** `serviceName` +{type-string}+ A "service.name" value. If specified this overrides any value from an active APM agent.
+** `serviceVersion` +{type-string}+ A "service.version" value. If specified this overrides any value from an active APM agent.
+** `serviceEnvironment` +{type-string}+ A "service.environment" value. If specified this overrides any value from an active APM agent.
+** `serviceNodeName` +{type-string}+ A "service.node.name" value. If specified this overrides any value from an active APM agent.
+** `eventDataset` +{type-string}+ A "event.dataset" value. If specified this overrides the default of using `${serviceVersion}`.
+
+Create a formatter for winston that emits in ECS Logging format.

--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 ## Unreleased
 
+- Add `service.version`, `service.environment`, and `service.node.name` log
+  correlation fields, automatically inferred from an active APM agent. As
+  well, the following `ecsFormat` configuration options have been added for
+  overriding these and existing correlation fields: `serviceName`,
+  `serviceVersion`, `serviceEnvironment`, `serviceNodeName`.
+  (https://github.com/elastic/apm-agent-nodejs/issues/3195,
+  https://github.com/elastic/ecs-logging-nodejs/issues/121,
+  https://github.com/elastic/ecs-logging-nodejs/issues/87)
+
 - Change to adding dotted field names (`"ecs.version": "1.6.0"`), rather than
   namespaced fields (`"ecs": {"version": "1.6.0"}`) for most fields. This is
   supported by the ecs-logging spec, and arguably preferred in the ECS logging
   docs. It is also what the ecs-logging-java libraries do. The resulting output
   is slightly shorter, and accidental collisions with user fields is less
   likely.
+
 - Stop adding ".log" suffix to `event.dataset` field.
   ([#95](https://github.com/elastic/ecs-logging-nodejs/issues/95))
 

--- a/loggers/morgan/README.md
+++ b/loggers/morgan/README.md
@@ -28,7 +28,7 @@ const app = require('express')()
 const morgan = require('morgan')
 const ecsFormat = require('@elastic/ecs-morgan-format')
 
-app.use(morgan(ecsFormat()))
+app.use(morgan(ecsFormat(/* options */)))
 
 app.get('/', function (req, res) {
   res.send('hello, world!')
@@ -43,18 +43,16 @@ produce log output similar to the following:
 ```sh
 % node examples/express.js | jq .  # piping to jq for pretty-printing
 {
-  "@timestamp": "2021-01-16T00:03:23.279Z",
+  "@timestamp": "2023-10-16T22:00:33.782Z",
   "log.level": "info",
-  "message": "::1 - - [16/Jan/2021:00:03:23 +0000] \"GET / HTTP/1.1\" 200 13 \"-\" \"curl/7.64.1\"",
-  "ecs": {
-    "version": "1.6.0"
-  },
+  "message": "::ffff:127.0.0.1 - - [16/Oct/2023:22:00:33 +0000] \"GET / HTTP/1.1\" 200 13 \"-\" \"curl/8.1.2\"",
   "http": {
     "version": "1.1",
     "request": {
       "method": "GET",
       "headers": {
         "host": "localhost:3000",
+        "user-agent": "curl/8.1.2",
         "accept": "*/*"
       }
     },
@@ -63,6 +61,7 @@ produce log output similar to the following:
       "headers": {
         "x-powered-by": "Express",
         "content-type": "text/html; charset=utf-8",
+        "content-length": "13",
         "etag": "W/\"d-HwnTDHB9U/PRbFMN1z1wps51lqk\""
       },
       "body": {
@@ -75,9 +74,15 @@ produce log output similar to the following:
     "domain": "localhost",
     "full": "http://localhost:3000/"
   },
+  "client": {
+    "address": "::ffff:127.0.0.1",
+    "ip": "::ffff:127.0.0.1",
+    "port": 60455
+  },
   "user_agent": {
-    "original": "curl/7.64.1"
-  }
+    "original": "curl/8.1.2"
+  },
+  "ecs.version": "1.6.0"
 }
 ```
 

--- a/loggers/morgan/test/apm.test.js
+++ b/loggers/morgan/test/apm.test.js
@@ -79,7 +79,12 @@ test('tracing integration works', t => {
       [
         path.join(__dirname, 'serve-one-http-req-with-apm.js'),
         apmServerUrl
-      ]
+      ],
+      {
+        env: Object.assign({}, process.env, {
+          ELASTIC_APM_SERVICE_NODE_NAME: 'serviceNodeNameFromEnv'
+        })
+      }
     )
     let handledFirstLogLine = false
     app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
@@ -134,8 +139,11 @@ test('tracing integration works', t => {
       const tx = traceObjs[1].transaction
       t.equal(logObjs[0]['trace.id'], tx.trace_id, 'trace.id matches')
       t.equal(logObjs[0]['transaction.id'], tx.id, 'transaction.id matches')
-      t.equal(logObjs[0]['service.name'], 'test-apm')
-      t.equal(logObjs[0]['event.dataset'], 'test-apm')
+      t.equal(logObjs[0]['service.name'], 'test-apm', 'service.name')
+      t.equal(logObjs[0]['service.version'], 'override-serviceVersion', 'service.version')
+      t.equal(logObjs[0]['service.environment'], 'development', 'service.environment')
+      t.equal(logObjs[0]['service.node.name'], 'serviceNodeNameFromEnv', 'service.node.name')
+      t.equal(logObjs[0]['event.dataset'], 'test-apm', 'event.dataset')
       finish()
     }
   }

--- a/loggers/morgan/test/basic.test.js
+++ b/loggers/morgan/test/basic.test.js
@@ -207,3 +207,31 @@ test('"log.level" for failing response is "error"', t => {
     t.end()
   })
 })
+
+test('can configure correlation fields', t => {
+  t.plan(6)
+
+  const stream = split().on('data', line => {
+    const rec = JSON.parse(line)
+    t.equal(rec['service.name'], 'override-serviceName')
+    t.equal(rec['service.version'], 'override-serviceVersion')
+    t.equal(rec['service.environment'], 'override-serviceEnvironment')
+    t.equal(rec['service.node.name'], 'override-serviceNodeName')
+    t.equal(rec['event.dataset'], 'override-eventDataset')
+  })
+  const logger = morgan(
+    ecsFormat({
+      serviceName: 'override-serviceName',
+      serviceVersion: 'override-serviceVersion',
+      serviceEnvironment: 'override-serviceEnvironment',
+      serviceNodeName: 'override-serviceNodeName',
+      eventDataset: 'override-eventDataset'
+    }),
+    { stream }
+  )
+
+  makeExpressServerAndRequest(logger, '/error', {}, null, function (err) {
+    t.error(err)
+    t.end()
+  })
+})

--- a/loggers/morgan/test/serve-one-http-req-with-apm.js
+++ b/loggers/morgan/test/serve-one-http-req-with-apm.js
@@ -46,7 +46,7 @@ const http = require('http')
 const morgan = require('morgan')
 const ecsFormat = require('../') // @elastic/ecs-morgan-format
 
-const ecsOpts = {}
+const ecsOpts = { serviceVersion: 'override-serviceVersion' }
 if (disableApmIntegration) {
   ecsOpts.apmIntegration = false
 }

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 ## Unreleased
 
+- Add `service.version`, `service.environment`, and `service.node.name` log
+  correlation fields, automatically inferred from an active APM agent. As
+  well, the following `ecsFormat` configuration options have been added for
+  overriding these and existing correlation fields: `serviceName`,
+  `serviceVersion`, `serviceEnvironment`, `serviceNodeName`.
+  (https://github.com/elastic/apm-agent-nodejs/issues/3195,
+  https://github.com/elastic/ecs-logging-nodejs/issues/121,
+  https://github.com/elastic/ecs-logging-nodejs/issues/87)
+
 - Change to adding dotted field names (`"ecs.version": "1.6.0"`), rather than
   namespaced fields (`"ecs": {"version": "1.6.0"}`) for most fields. This is
   supported by the ecs-logging spec, and arguably preferred in the ECS logging
   docs. It is also what the ecs-logging-java libraries do. The resulting output
   is slightly shorter, and accidental collisions with user fields is less
   likely.
+
 - Stop adding ".log" suffix to `event.dataset` field.
   ([#95](https://github.com/elastic/ecs-logging-nodejs/issues/95))
 

--- a/loggers/pino/README.md
+++ b/loggers/pino/README.md
@@ -28,7 +28,7 @@ This package will configure Pino's `formatters`, `messageKey` and `timestamp` op
 const ecsFormat = require('@elastic/ecs-pino-format')
 const pino = require('pino')
 
-const log = pino(ecsFormat())
+const log = pino(ecsFormat(/* options */))
 log.info('Hello world')
 
 const child = log.child({ module: 'foo' })

--- a/loggers/pino/index.d.ts
+++ b/loggers/pino/index.d.ts
@@ -5,26 +5,47 @@ interface Config {
    * Whether to convert a logged `err` field to ECS error fields.
    * Default true, to match Pino's default of having an `err` serializer.
    */
+
   convertErr?: boolean;
   /**
    * Whether to convert logged `req` and `res` HTTP request and response fields
    * to ECS HTTP, User agent, and URL fields. Default false.
    */
+
   convertReqRes?: boolean;
+
   /**
    * Whether to automatically integrate with
    * Elastic APM (https://github.com/elastic/apm-agent-nodejs). If a started
    * APM agent is detected, then log records will include the following
    * fields:
    *
-   * - "service.name" - the configured serviceName in the agent
-   * - "event.dataset" - set to "$serviceName" for correlation in Kibana
    * - "trace.id", "transaction.id", and "span.id" - if there is a current
    *   active trace when the log call is made
+   *
+   * and also the following fields, if not already specified in this config:
+   *
+   * - "service.name" - the configured `serviceName` in the agent
+   * - "service.version" - the configured `serviceVersion` in the agent
+   * - "service.environment" - the configured `environment` in the agent
+   * - "service.node.name" - the configured `serviceNodeName` in the agent
+   * - "event.dataset" - set to `${serviceName}` for correlation in Kibana
    *
    * Default true.
    */
   apmIntegration?: boolean;
+
+  /** Specify "service.name" field. Defaults to a value from the APM agent, if available. */
+  serviceName?: string;
+  /** Specify "service.version" field. Defaults to a value from the APM agent, if available. */
+  serviceVersion?: string;
+  /** Specify "service.environment" field. Defaults to a value from the APM agent, if available. */
+  serviceEnvironment?: string;
+  /** Specify "service.node.name" field. Defaults to a value from the APM agent, if available. */
+  serviceNodeName?: string;
+  /** Specify "event.dataset" field. Defaults `${serviceName}`. */
+  eventDataset?: string;
+
 }
 
 declare function createEcsPinoOptions(config?: Config): LoggerOptions;

--- a/loggers/pino/test/apm.test.js
+++ b/loggers/pino/test/apm.test.js
@@ -79,7 +79,12 @@ test('tracing integration works', t => {
       [
         path.join(__dirname, 'serve-one-http-req-with-apm.js'),
         apmServerUrl
-      ]
+      ],
+      {
+        env: Object.assign({}, process.env, {
+          ELASTIC_APM_SERVICE_NODE_NAME: 'serviceNodeNameFromEnv'
+        })
+      }
     )
     let handledFirstLogLine = false
     app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
@@ -133,8 +138,11 @@ test('tracing integration works', t => {
       t.equal(logObjs[0]['trace.id'], span.trace_id, 'trace.id matches')
       t.equal(logObjs[0]['transaction.id'], span.transaction_id, 'transaction.id matches')
       t.equal(logObjs[0]['span.id'], span.id, 'span.id matches')
-      t.equal(logObjs[0]['service.name'], 'test-apm')
-      t.equal(logObjs[0]['event.dataset'], 'test-apm')
+      t.equal(logObjs[0]['service.name'], 'test-apm', 'service.name')
+      t.equal(logObjs[0]['service.version'], 'override-serviceVersion', 'service.version')
+      t.equal(logObjs[0]['service.environment'], 'development', 'service.environment')
+      t.equal(logObjs[0]['service.node.name'], 'serviceNodeNameFromEnv', 'service.node.name')
+      t.equal(logObjs[0]['event.dataset'], 'test-apm', 'event.dataset')
       finish()
     }
   }

--- a/loggers/pino/test/serve-one-http-req-with-apm.js
+++ b/loggers/pino/test/serve-one-http-req-with-apm.js
@@ -44,7 +44,10 @@ const http = require('http')
 const ecsFormat = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
-const ecsOpts = { convertReqRes: true }
+const ecsOpts = {
+  convertReqRes: true,
+  serviceVersion: 'override-serviceVersion'
+}
 if (disableApmIntegration) {
   ecsOpts.apmIntegration = false
 }

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 ## Unreleased
 
+- Add `service.version`, `service.environment`, and `service.node.name` log
+  correlation fields, automatically inferred from an active APM agent. As
+  well, the following `ecsFormat` configuration options have been added for
+  overriding these and existing correlation fields: `serviceName`,
+  `serviceVersion`, `serviceEnvironment`, `serviceNodeName`.
+  (https://github.com/elastic/apm-agent-nodejs/issues/3195,
+  https://github.com/elastic/ecs-logging-nodejs/issues/121,
+  https://github.com/elastic/ecs-logging-nodejs/issues/87)
+
 - Change to adding dotted field names (`"ecs.version": "1.6.0"`), rather than
   namespaced fields (`"ecs": {"version": "1.6.0"}`) for most fields. This is
   supported by the ecs-logging spec, and arguably preferred in the ECS logging
   docs. It is also what the ecs-logging-java libraries do. The resulting output
   is slightly shorter, and accidental collisions with user fields is less
   likely.
+
 - Stop adding ".log" suffix to `event.dataset` field.
   ([#95](https://github.com/elastic/ecs-logging-nodejs/issues/95))
 

--- a/loggers/winston/README.md
+++ b/loggers/winston/README.md
@@ -29,7 +29,7 @@ const ecsFormat = require('@elastic/ecs-winston-format')
 
 const logger = winston.createLogger({
   level: 'info',
-  format: ecsFormat(),
+  format: ecsFormat(/* options */),
   transports: [
     new winston.transports.Console()
   ]

--- a/loggers/winston/index.d.ts
+++ b/loggers/winston/index.d.ts
@@ -6,25 +6,44 @@ interface Config {
    * Default true.
    */
   convertErr?: boolean;
+
   /**
    * Whether to convert logged `req` and `res` HTTP request and response fields
    * to ECS HTTP, User agent, and URL fields. Default false.
    */
   convertReqRes?: boolean;
+
   /**
    * Whether to automatically integrate with
    * Elastic APM (https://github.com/elastic/apm-agent-nodejs). If a started
    * APM agent is detected, then log records will include the following
    * fields:
    *
-   * - "service.name" - the configured serviceName in the agent
-   * - "event.dataset" - set to "$serviceName" for correlation in Kibana
    * - "trace.id", "transaction.id", and "span.id" - if there is a current
    *   active trace when the log call is made
+   *
+   * and also the following fields, if not already specified in this config:
+   *
+   * - "service.name" - the configured `serviceName` in the agent
+   * - "service.version" - the configured `serviceVersion` in the agent
+   * - "service.environment" - the configured `environment` in the agent
+   * - "service.node.name" - the configured `serviceNodeName` in the agent
+   * - "event.dataset" - set to `${serviceName}` for correlation in Kibana
    *
    * Default true.
    */
   apmIntegration?: boolean;
+
+  /** Specify "service.name" field. Defaults to a value from the APM agent, if available. */
+  serviceName?: string;
+  /** Specify "service.version" field. Defaults to a value from the APM agent, if available. */
+  serviceVersion?: string;
+  /** Specify "service.environment" field. Defaults to a value from the APM agent, if available. */
+  serviceEnvironment?: string;
+  /** Specify "service.node.name" field. Defaults to a value from the APM agent, if available. */
+  serviceNodeName?: string;
+  /** Specify "event.dataset" field. Defaults `${serviceName}`. */
+  eventDataset?: string;
 }
 
 declare function ecsFormat(opts?: Config): Logform.Format;

--- a/loggers/winston/test/apm.test.js
+++ b/loggers/winston/test/apm.test.js
@@ -79,7 +79,12 @@ test('tracing integration works', t => {
       [
         path.join(__dirname, 'serve-one-http-req-with-apm.js'),
         apmServerUrl
-      ]
+      ],
+      {
+        env: Object.assign({}, process.env, {
+          ELASTIC_APM_SERVICE_NODE_NAME: 'serviceNodeNameFromEnv'
+        })
+      }
     )
     let handledFirstLogLine = false
     app.stdout.pipe(split(JSON.parse)).on('data', function (logObj) {
@@ -135,8 +140,11 @@ test('tracing integration works', t => {
       t.equal(logObjs[0]['trace.id'], span.trace_id, 'trace.id matches')
       t.equal(logObjs[0]['transaction.id'], span.transaction_id, 'transaction.id matches')
       t.equal(logObjs[0]['span.id'], span.id, 'span.id matches')
-      t.equal(logObjs[0]['service.name'], 'test-apm', 'service.name matches')
-      t.equal(logObjs[0]['event.dataset'], 'test-apm', 'event.dataset matches')
+      t.equal(logObjs[0]['service.name'], 'test-apm', 'service.name')
+      t.equal(logObjs[0]['service.version'], 'override-serviceVersion', 'service.version')
+      t.equal(logObjs[0]['service.environment'], 'development', 'service.environment')
+      t.equal(logObjs[0]['service.node.name'], 'serviceNodeNameFromEnv', 'service.node.name')
+      t.equal(logObjs[0]['event.dataset'], 'test-apm', 'event.dataset')
       finish()
     }
   }

--- a/loggers/winston/test/basic.test.js
+++ b/loggers/winston/test/basic.test.js
@@ -277,3 +277,26 @@ test('convertErr=false allows passing through err=<non-Error>', t => {
   t.equal(rec.error, undefined, 'no rec.error is set')
   t.end()
 })
+
+test('can configure correlation fields', t => {
+  const cap = new CaptureTransport()
+  const logger = winston.createLogger({
+    format: ecsFormat({
+      serviceName: 'override-serviceName',
+      serviceVersion: 'override-serviceVersion',
+      serviceEnvironment: 'override-serviceEnvironment',
+      serviceNodeName: 'override-serviceNodeName',
+      eventDataset: 'override-eventDataset'
+    }),
+    transports: [cap]
+  })
+  logger.info('hi')
+
+  const rec = cap.records[0]
+  t.equal(rec['service.name'], 'override-serviceName')
+  t.equal(rec['service.version'], 'override-serviceVersion')
+  t.equal(rec['service.environment'], 'override-serviceEnvironment')
+  t.equal(rec['service.node.name'], 'override-serviceNodeName')
+  t.equal(rec['event.dataset'], 'override-eventDataset')
+  t.end()
+})

--- a/loggers/winston/test/serve-one-http-req-with-apm.js
+++ b/loggers/winston/test/serve-one-http-req-with-apm.js
@@ -44,7 +44,10 @@ const http = require('http')
 const ecsFormat = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
-const ecsOpts = { convertReqRes: true }
+const ecsOpts = {
+  convertReqRes: true,
+  serviceVersion: 'override-serviceVersion'
+}
 if (disableApmIntegration) {
   ecsOpts.apmIntegration = false
 }


### PR DESCRIPTION
These are retrieved from an active APM agent, if apmIntegration is
enabled. As well, config options for overriding these (and service.name)
have been added.

Closes: #121
Closes: #87
Refs: https://github.com/elastic/apm-agent-nodejs/issues/3195
