### PR TITLE
v1.4.0

### DIFF
--- a/loggers/morgan/CHANGELOG.md
+++ b/loggers/morgan/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-morgan-format Changelog
 
-## Unreleased
+## v1.4.0
 
 - Add `service.version`, `service.environment`, and `service.node.name` log
   correlation fields, automatically inferred from an active APM agent. As

--- a/loggers/morgan/package.json
+++ b/loggers/morgan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-morgan-format",
-  "version": "1.1.0",
+  "version": "1.4.0",
   "description": "A formatter for the morgan logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [

--- a/loggers/pino/CHANGELOG.md
+++ b/loggers/pino/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-pino-format Changelog
 
-## Unreleased
+## v1.4.0
 
 - Add `service.version`, `service.environment`, and `service.node.name` log
   correlation fields, automatically inferred from an active APM agent. As

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-pino-format",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [

--- a/loggers/winston/CHANGELOG.md
+++ b/loggers/winston/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-winston-format Changelog
 
-## Unreleased
+## v1.4.0
 
 - Add `service.version`, `service.environment`, and `service.node.name` log
   correlation fields, automatically inferred from an active APM agent. As

--- a/loggers/winston/package.json
+++ b/loggers/winston/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# highlights

- Adds `service.version`, `service.environment`, and `service.node.name` fields for log correlation with an active APM agent; or manually configured values for those fields via `serviceVersion` et al config options to the formatters. (#87, #121)
- Change to prefer the dotted name for most fields in ECS log format output. For example: `...,"ecs.version":"...","service.name":"...",...` rather than `...,{"ecs":{"version":"..."}},{"service":{"name":"..."}},...`. The main benefit is that the code in the formatters is vastly simplified, which is good for maintenance and overhead. A minor benefit is the resultant serialized output tends to be a bit shorter.

# changelogs

- https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/morgan/CHANGELOG.md#v140
- https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/pino/CHANGELOG.md#v140
- https://github.com/elastic/ecs-logging-nodejs/blob/main/loggers/winston/CHANGELOG.md#v140
