### PR TITLE
fix: bump version of fast-json-stringify to avoid unsupported sub-dep…

### DIFF
--- a/packages/ecs-helpers/package.json
+++ b/packages/ecs-helpers/package.json
@@ -25,7 +25,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "fast-json-stringify": "^2.4.1"
+    "fast-json-stringify": "^5.8.0"
   },
   "devDependencies": {
     "@hapi/hapi": "^20.1.0",


### PR DESCRIPTION
fast-json-stringify version 2.4.1 depeneds on unsupported package string-similarity. Bumped version to 5.8.0 to avoid unsupported dependency.