### PR TITLE
feat(winston): improve serialization of Error instances

### DIFF
--- a/packages/ecs-winston-format/index.js
+++ b/packages/ecs-winston-format/index.js
@@ -186,7 +186,8 @@ class EcsWinstonTransform {
       // always a string to avoid its type varying depending on the value.
       if (err.cause) {
         ecsFields.error.cause = err.cause instanceof Error
-          ? err.cause.stack : err.cause.toString()
+          ? err.cause.stack
+          : err.cause.toString()
       }
     }
 

--- a/packages/ecs-winston-format/index.js
+++ b/packages/ecs-winston-format/index.js
@@ -184,6 +184,7 @@ class EcsWinstonTransform {
       // The add some additional fields. `cause` is handled by
       // `logform.errors({cause: true})`.  This implementation ensures it is
       // always a string to avoid its type varying depending on the value.
+      // istanbul ignore next -- so coverage works for Node.js <16.9.0
       if (err.cause) {
         ecsFields.error.cause = err.cause instanceof Error
           ? err.cause.stack

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -49,6 +49,7 @@
     "autocannon": "^7.0.1",
     "elastic-apm-node": "^3.23.0",
     "express": "^4.17.1",
+    "semver": "^7.5.4",
     "split2": "^3.2.2",
     "standard": "16.x",
     "tap": "^15.0.10",

--- a/packages/ecs-winston-format/test/errors.test.js
+++ b/packages/ecs-winston-format/test/errors.test.js
@@ -1,0 +1,216 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+// Test the various error/exception handling cases.
+
+const { execFile } = require('child_process')
+const test = require('tap').test
+const { MESSAGE } = require('triple-beam')
+const winston = require('winston')
+const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
+const { validate, CaptureTransport } = require('./utils')
+
+const ecsFormat = require('../')
+
+test('log.info("msg", new Error("boom"))', t => {
+  const cap = new CaptureTransport()
+  const log = winston.createLogger({
+    // Set `convertErr: false` to ensure this form of passing an Error to
+    // a Winston logger is handled by default.
+    format: ecsFormat({ convertErr: false }),
+    defaultMeta: { aField: 'defaultMeta field value'},
+    transports: [cap]
+  })
+
+  const errCause = new Error('the cause')
+  const err = new Error('boom', { cause: errCause })
+  err.aField = 'err field value'
+  log.info('msg', err)
+
+  const rec = cap.records[0]
+  t.ok(validate(rec))
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(rec.message, 'msg boom') // Winston core appends the err.message to the message.
+  // Ideally we'd expect `aField: 'defaultMeta field value'`, but Winston
+  // core error handling overwrites with `err.aField`. The ECS formatter
+  // moves that err property from the record top-level to `error.`.
+  t.equal(rec.aField, undefined)
+  t.equal(rec.error.type, 'Error')
+  t.equal(rec.error.message, 'boom')
+  t.match(rec.error.stack_trace, /^Error: boom\n    at/)
+  t.equal(rec.error.aField, 'err field value')
+  t.match(rec.error.cause, /^Error: the cause\n    at/)
+  t.end()
+})
+
+test('uncaughtException winston log error message', t => {
+  execFile(
+    process.execPath,
+    ['uncaught-exception.js'],
+    {
+      cwd: __dirname,
+      timeout: 5000
+    },
+    function (err, stdout, _stderr) {
+      t.ok(err, 'script exited non-zero')
+      const recs = stdout.trim().split(/\n/g).map(JSON.parse)
+      t.equal(recs.length, 1)
+      const rec = recs[0]
+      t.equal(rec['log.level'], 'error', 'log.level')
+      t.equal(rec.message, 'uncaughtException: funcb boom', 'message')
+      t.equal(rec.error.type, 'Error', 'error.type')
+      t.equal(rec.error.message, 'funcb boom', 'error.message')
+      t.match(rec.error.stack_trace, /^Error: funcb boom\n    at/, 'error.stack_trace')
+      t.equal(rec.error.code, 42, 'error.code')
+      t.equal(rec.exception, true, 'exception')
+      t.end()
+    }
+  )
+})
+
+test('unhandledRejection winston log error message', t => {
+  execFile(
+    process.execPath,
+    ['unhandled-rejection.js'],
+    {
+      cwd: __dirname,
+      timeout: 5000
+    },
+    function (err, stdout, _stderr) {
+      t.ok(err, 'script exited non-zero')
+      const recs = stdout.trim().split(/\n/g).map(JSON.parse)
+      t.equal(recs.length, 1)
+      const rec = recs[0]
+      t.equal(rec['log.level'], 'error', 'log.level')
+      t.equal(rec.message, 'unhandledRejection: funcb boom', 'message')
+      t.equal(rec.error.type, 'Error', 'error.type')
+      t.equal(rec.error.message, 'funcb boom', 'error.message')
+      t.match(rec.error.stack_trace, /^Error: funcb boom\n    at/, 'error.stack_trace')
+      t.equal(rec.error.code, 42, 'error.code')
+      t.equal(rec.exception, true, 'exception')
+      t.end()
+    }
+  )
+})
+
+test('log.info(new Error("boom"))', t => {
+  const cap = new CaptureTransport()
+  const log = winston.createLogger({
+    format: ecsFormat({ convertErr: true }),
+    defaultMeta: { aField: 'defaultMeta field value'},
+    transports: [cap]
+  })
+
+  const errCause = 'the cause is a string'
+  const err = new Error('boom', { cause: errCause })
+  err.aField = 'err field value'
+  log.info(err)
+
+  const rec = cap.records[0]
+  t.ok(validate(rec))
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(rec.message, 'boom', 'message')
+  t.equal(rec.aField, 'defaultMeta field value', 'aField')
+  t.equal(rec.error.type, 'Error', 'error.type')
+  t.equal(rec.error.message, 'boom', 'error.message')
+  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  // Winston mixes `err` properties and `defaultMeta` at the top-level, so
+  // conflicts result in lost date.
+  t.equal(rec.error.aField, 'defaultMeta field value', 'error.aField')
+  t.equal(rec.error.cause, 'the cause is a string', 'error.cause')
+  t.end()
+})
+
+test('log.info(new Error("boom"), {...})', t => {
+  const cap = new CaptureTransport()
+  const log = winston.createLogger({
+    format: ecsFormat({ convertErr: true }),
+    defaultMeta: { aField: 'defaultMeta field value'},
+    transports: [cap]
+  })
+
+  const errCause = new Error('the cause')
+  const err = new Error('boom', { cause: errCause })
+  err.aField = 'err field value'
+  log.info(err, { aField: 'splat field value'})
+
+  const rec = cap.records[0]
+  t.ok(validate(rec))
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(rec.message, 'boom', 'message')
+  t.equal(rec.aField, 'splat field value', 'aField')
+  t.equal(rec.error.type, 'Error', 'error.type')
+  t.equal(rec.error.message, 'boom', 'error.message')
+  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  t.equal(rec.error.aField, 'err field value', 'error.aField')
+  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.end()
+})
+
+test('log.info(new Error("")) with empty err.message', t => {
+  const cap = new CaptureTransport()
+  const log = winston.createLogger({
+    format: ecsFormat({ convertErr: true }),
+    defaultMeta: { aField: 'defaultMeta field value'},
+    transports: [cap]
+  })
+
+  const errCause = new Error('the cause')
+  const err = new Error('', { cause: errCause })
+  err.aField = 'err field value'
+  log.info(err)
+
+  const rec = cap.records[0]
+  t.ok(validate(rec))
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(rec.message, '', 'message')
+  t.equal(rec.aField, 'defaultMeta field value', 'aField')
+  t.equal(rec.error.type, 'Error', 'error.type')
+  t.equal(rec.error.message, '', 'error.message')
+  t.match(rec.error.stack_trace, /^Error: \n    at/, 'error.stack_trace')
+  t.equal(rec.error.aField, 'err field value', 'error.aField')
+  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.end()
+})
+
+test('log.info("msg", { err: new Error("boom") })', t => {
+  const cap = new CaptureTransport()
+  const log = winston.createLogger({
+    format: ecsFormat({ convertErr: true }),
+    defaultMeta: { aField: 'defaultMeta field value'},
+    transports: [cap]
+  })
+
+  const errCause = new Error('the cause')
+  const err = new Error('boom', { cause: errCause })
+  err.aField = 'err field value'
+  log.info('msg', { err, aField: 'splat field value' })
+
+  const rec = cap.records[0]
+  t.ok(validate(rec))
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(rec.message, 'msg', 'message')
+  t.equal(rec.aField, 'splat field value', 'aField')
+  t.equal(rec.error.type, 'Error', 'error.type')
+  t.equal(rec.error.message, 'boom', 'error.message')
+  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  t.equal(rec.error.aField, 'err field value', 'error.aField')
+  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.end()
+})

--- a/packages/ecs-winston-format/test/errors.test.js
+++ b/packages/ecs-winston-format/test/errors.test.js
@@ -34,7 +34,7 @@ test('log.info("msg", new Error("boom"))', t => {
     // Set `convertErr: false` to ensure this form of passing an Error to
     // a Winston logger is handled by default.
     format: ecsFormat({ convertErr: false }),
-    defaultMeta: { aField: 'defaultMeta field value'},
+    defaultMeta: { aField: 'defaultMeta field value' },
     transports: [cap]
   })
 
@@ -53,9 +53,9 @@ test('log.info("msg", new Error("boom"))', t => {
   t.equal(rec.aField, undefined)
   t.equal(rec.error.type, 'Error')
   t.equal(rec.error.message, 'boom')
-  t.match(rec.error.stack_trace, /^Error: boom\n    at/)
+  t.match(rec.error.stack_trace, /^Error: boom\n {4}at/)
   t.equal(rec.error.aField, 'err field value')
-  t.match(rec.error.cause, /^Error: the cause\n    at/)
+  t.match(rec.error.cause, /^Error: the cause\n {4}at/)
   t.end()
 })
 
@@ -76,7 +76,7 @@ test('uncaughtException winston log error message', t => {
       t.equal(rec.message, 'uncaughtException: funcb boom', 'message')
       t.equal(rec.error.type, 'Error', 'error.type')
       t.equal(rec.error.message, 'funcb boom', 'error.message')
-      t.match(rec.error.stack_trace, /^Error: funcb boom\n    at/, 'error.stack_trace')
+      t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
       t.equal(rec.error.code, 42, 'error.code')
       t.equal(rec.exception, true, 'exception')
       t.end()
@@ -101,7 +101,7 @@ test('unhandledRejection winston log error message', t => {
       t.equal(rec.message, 'unhandledRejection: funcb boom', 'message')
       t.equal(rec.error.type, 'Error', 'error.type')
       t.equal(rec.error.message, 'funcb boom', 'error.message')
-      t.match(rec.error.stack_trace, /^Error: funcb boom\n    at/, 'error.stack_trace')
+      t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
       t.equal(rec.error.code, 42, 'error.code')
       t.equal(rec.exception, true, 'exception')
       t.end()
@@ -113,7 +113,7 @@ test('log.info(new Error("boom"))', t => {
   const cap = new CaptureTransport()
   const log = winston.createLogger({
     format: ecsFormat({ convertErr: true }),
-    defaultMeta: { aField: 'defaultMeta field value'},
+    defaultMeta: { aField: 'defaultMeta field value' },
     transports: [cap]
   })
 
@@ -129,7 +129,7 @@ test('log.info(new Error("boom"))', t => {
   t.equal(rec.aField, 'defaultMeta field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
   t.equal(rec.error.message, 'boom', 'error.message')
-  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  t.match(rec.error.stack_trace, /^Error: boom\n {4}at/, 'error.stack_trace')
   // Winston mixes `err` properties and `defaultMeta` at the top-level, so
   // conflicts result in lost date.
   t.equal(rec.error.aField, 'defaultMeta field value', 'error.aField')
@@ -141,14 +141,14 @@ test('log.info(new Error("boom"), {...})', t => {
   const cap = new CaptureTransport()
   const log = winston.createLogger({
     format: ecsFormat({ convertErr: true }),
-    defaultMeta: { aField: 'defaultMeta field value'},
+    defaultMeta: { aField: 'defaultMeta field value' },
     transports: [cap]
   })
 
   const errCause = new Error('the cause')
   const err = new Error('boom', { cause: errCause })
   err.aField = 'err field value'
-  log.info(err, { aField: 'splat field value'})
+  log.info(err, { aField: 'splat field value' })
 
   const rec = cap.records[0]
   t.ok(validate(rec))
@@ -157,9 +157,9 @@ test('log.info(new Error("boom"), {...})', t => {
   t.equal(rec.aField, 'splat field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
   t.equal(rec.error.message, 'boom', 'error.message')
-  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  t.match(rec.error.stack_trace, /^Error: boom\n {4}at/, 'error.stack_trace')
   t.equal(rec.error.aField, 'err field value', 'error.aField')
-  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.match(rec.error.cause, /^Error: the cause\n {4}at/, 'error.cause')
   t.end()
 })
 
@@ -167,7 +167,7 @@ test('log.info(new Error("")) with empty err.message', t => {
   const cap = new CaptureTransport()
   const log = winston.createLogger({
     format: ecsFormat({ convertErr: true }),
-    defaultMeta: { aField: 'defaultMeta field value'},
+    defaultMeta: { aField: 'defaultMeta field value' },
     transports: [cap]
   })
 
@@ -183,9 +183,9 @@ test('log.info(new Error("")) with empty err.message', t => {
   t.equal(rec.aField, 'defaultMeta field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
   t.equal(rec.error.message, '', 'error.message')
-  t.match(rec.error.stack_trace, /^Error: \n    at/, 'error.stack_trace')
+  t.match(rec.error.stack_trace, /^Error: \n {4}at/, 'error.stack_trace')
   t.equal(rec.error.aField, 'err field value', 'error.aField')
-  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.match(rec.error.cause, /^Error: the cause\n {4}at/, 'error.cause')
   t.end()
 })
 
@@ -193,7 +193,7 @@ test('log.info("msg", { err: new Error("boom") })', t => {
   const cap = new CaptureTransport()
   const log = winston.createLogger({
     format: ecsFormat({ convertErr: true }),
-    defaultMeta: { aField: 'defaultMeta field value'},
+    defaultMeta: { aField: 'defaultMeta field value' },
     transports: [cap]
   })
 
@@ -209,8 +209,8 @@ test('log.info("msg", { err: new Error("boom") })', t => {
   t.equal(rec.aField, 'splat field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
   t.equal(rec.error.message, 'boom', 'error.message')
-  t.match(rec.error.stack_trace, /^Error: boom\n    at/, 'error.stack_trace')
+  t.match(rec.error.stack_trace, /^Error: boom\n {4}at/, 'error.stack_trace')
   t.equal(rec.error.aField, 'err field value', 'error.aField')
-  t.match(rec.error.cause, /^Error: the cause\n    at/, 'error.cause')
+  t.match(rec.error.cause, /^Error: the cause\n {4}at/, 'error.cause')
   t.end()
 })

--- a/packages/ecs-winston-format/test/uncaught-exception.js
+++ b/packages/ecs-winston-format/test/uncaught-exception.js
@@ -17,28 +17,27 @@
 
 'use strict'
 
-const winston = require('winston')
 const ecsFormat = require('../') // @elastic/ecs-winston-format
+const winston = require('winston')
 
-const logger = winston.createLogger({
+const log = winston.createLogger({
   level: 'info',
   format: ecsFormat(),
-  // Compare to:
-  // format: winston.format.combine(
-  //   winston.format.errors({stack: true, cause: true}),
-  //   winston.format.json()
-  // ),
   transports: [
     new winston.transports.Console({
-      handleExceptions: true,
-      handleRejections: true
+      handleExceptions: true
     })
   ]
 })
 
-logger.info('hi')
-logger.warn('look out', { foo: 'bar' })
+function funcb() {
+  const e = new Error('funcb boom')
+  e.code = 42
+  throw e
+}
 
-const err = new Error('boom', { cause: new Error('the cause') })
-err.code = 42
-logger.error('here is an exception', err)
+function funca() {
+  funcb()
+}
+
+funca()

--- a/packages/ecs-winston-format/test/uncaught-exception.js
+++ b/packages/ecs-winston-format/test/uncaught-exception.js
@@ -20,6 +20,7 @@
 const ecsFormat = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
+// eslint-disable-next-line
 const log = winston.createLogger({
   level: 'info',
   format: ecsFormat(),
@@ -30,13 +31,13 @@ const log = winston.createLogger({
   ]
 })
 
-function funcb() {
+function funcb () {
   const e = new Error('funcb boom')
   e.code = 42
   throw e
 }
 
-function funca() {
+function funca () {
   funcb()
 }
 

--- a/packages/ecs-winston-format/test/unhandled-rejection.js
+++ b/packages/ecs-winston-format/test/unhandled-rejection.js
@@ -17,17 +17,12 @@
 
 'use strict'
 
-const winston = require('winston')
 const ecsFormat = require('../') // @elastic/ecs-winston-format
+const winston = require('winston')
 
-const logger = winston.createLogger({
+const log = winston.createLogger({
   level: 'info',
   format: ecsFormat(),
-  // Compare to:
-  // format: winston.format.combine(
-  //   winston.format.errors({stack: true, cause: true}),
-  //   winston.format.json()
-  // ),
   transports: [
     new winston.transports.Console({
       handleExceptions: true,
@@ -36,9 +31,14 @@ const logger = winston.createLogger({
   ]
 })
 
-logger.info('hi')
-logger.warn('look out', { foo: 'bar' })
+async function funcb() {
+  const e = new Error('funcb boom')
+  e.code = 42
+  throw e
+}
 
-const err = new Error('boom', { cause: new Error('the cause') })
-err.code = 42
-logger.error('here is an exception', err)
+async function funca() {
+  await funcb()
+}
+
+funca()

--- a/packages/ecs-winston-format/test/unhandled-rejection.js
+++ b/packages/ecs-winston-format/test/unhandled-rejection.js
@@ -20,6 +20,7 @@
 const ecsFormat = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
+// eslint-disable-next-line
 const log = winston.createLogger({
   level: 'info',
   format: ecsFormat(),
@@ -31,13 +32,13 @@ const log = winston.createLogger({
   ]
 })
 
-async function funcb() {
+async function funcb () {
   const e = new Error('funcb boom')
   e.code = 42
   throw e
 }
 
-async function funca() {
+async function funca () {
   await funcb()
 }
 

--- a/packages/ecs-winston-format/test/utils.js
+++ b/packages/ecs-winston-format/test/utils.js
@@ -50,4 +50,3 @@ module.exports = {
   validate,
   CaptureTransport
 }
-

--- a/packages/ecs-winston-format/test/utils.js
+++ b/packages/ecs-winston-format/test/utils.js
@@ -17,28 +17,37 @@
 
 'use strict'
 
-const winston = require('winston')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const Transport = require('winston-transport')
+const { MESSAGE } = require('triple-beam')
+const addFormats = require('ajv-formats').default
+const Ajv = require('ajv').default
 
-const logger = winston.createLogger({
-  level: 'info',
-  format: ecsFormat(),
-  // Compare to:
-  // format: winston.format.combine(
-  //   winston.format.errors({stack: true, cause: true}),
-  //   winston.format.json()
-  // ),
-  transports: [
-    new winston.transports.Console({
-      handleExceptions: true,
-      handleRejections: true
-    })
-  ]
+const ajv = new Ajv({
+  allErrors: true,
+  verbose: true
 })
+addFormats(ajv)
+const validate = ajv.compile(require('../../../utils/schema.json'))
 
-logger.info('hi')
-logger.warn('look out', { foo: 'bar' })
+// Winston transport to capture logged records. Parsed JSON records are on
+// `.records`. Raw records (what Winston calls `info` objects) are on `.infos`.
+class CaptureTransport extends Transport {
+  constructor () {
+    super()
+    this.records = []
+    this.infos = []
+  }
 
-const err = new Error('boom', { cause: new Error('the cause') })
-err.code = 42
-logger.error('here is an exception', err)
+  log (info, callback) {
+    this.infos.push(info)
+    const record = JSON.parse(info[MESSAGE])
+    this.records.push(record)
+    callback()
+  }
+}
+
+module.exports = {
+  validate,
+  CaptureTransport
+}
+


### PR DESCRIPTION
This handles the various ways an Error instance can be passed
to a Winston logger, and serializes those Errors to 'error.*'
fields.

Closes: https://github.com/elastic/ecs-logging-nodejs/issues/128
