### PR TITLE
test: add TAV tests for pino and winston supported versions

### DIFF
--- a/.github/workflows/tav.yml
+++ b/.github/workflows/tav.yml
@@ -1,29 +1,17 @@
-## Test with multiple node versions.
-name: test
+## TAV (test-all-versions) tests to test with multiple versions of deps.
+name: tav
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch: ~
+  schedule:
+    # Weekly on Monday, 16:00 UTC, so hopefully near my PST morning.
+    - cron: '0 16 * * 1'
 
 permissions:
   contents: read
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - run: utils/run-install.sh
-      - run: utils/run-lint.sh
-
-  test:
+  tav:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -39,5 +27,5 @@ jobs:
         run: npm install -g npm@7 # npm@7 supports node >=10
       - name: Install dependencies
         run: utils/run-install.sh
-      - name: Test Node.js v${{ matrix.node-version }}
-        run: utils/run-test.sh
+      - name: TAV Node.js v${{ matrix.node-version }}
+        run: npm --workspaces run --if-present tav

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ all:
 test:
 	./utils/run-test.sh
 
+.PHONY: tav
+tav:
+	npm --workspaces run --if-present tav # requires npm>=7 (aka node>=16)
+
 .PHONY: lint
 lint: check-license-headers
 	./utils/run-lint.sh

--- a/docs/pino.asciidoc
+++ b/docs/pino.asciidoc
@@ -5,7 +5,7 @@ This Node.js package provides a formatter for the https://getpino.io[pino]
 logger, compatible with {ecs-logging-ref}/intro.html[Elastic Common Schema (ECS) logging].
 In combination with the https://www.elastic.co/beats/filebeat[Filebeat] shipper,
 you can https://www.elastic.co/log-monitoring[monitor all your logs] in one
-place in the Elastic Stack.
+place in the Elastic Stack. `pino` 6.x, 7.x, and 8.x versions are supported.
 
 
 [float]

--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -5,7 +5,7 @@ This Node.js package provides a formatter for the https://github.com/winstonjs/w
 logger, compatible with {ecs-logging-ref}/intro.html[Elastic Common Schema (ECS) logging].
 In combination with the https://www.elastic.co/beats/filebeat[Filebeat] shipper,
 you can https://www.elastic.co/log-monitoring[monitor all your logs] in one
-place in the Elastic Stack.
+place in the Elastic Stack. `winston` 3.x versions are supported.
 
 
 [float]

--- a/packages/ecs-pino-format/.tav.yml
+++ b/packages/ecs-pino-format/.tav.yml
@@ -1,0 +1,15 @@
+# Ideally we'd test all pino releases, but that is too many to justify the
+# compute time -- so we test a subset.
+pino:
+  - versions: '6.0.0 || ^6.14.0'
+    # versions: '^6.0.0'
+    node: '>=10 <17'
+    commands: 'npm test'
+  - versions: '7.0.0 || ^7.11.0'
+    # versions: '^7.0.0'
+    node: '>=12 <18'
+    commands: 'npm test'
+  - versions: '8.0.0 || >=8.16.1'
+    # versions: '>=8.0.0'
+    node: '>=14'
+    commands: 'npm test'

--- a/packages/ecs-pino-format/README.md
+++ b/packages/ecs-pino-format/README.md
@@ -11,6 +11,8 @@ shipper, you can send your logs directly to Elasticsearch and leverage
 [Kibana's Logs app](https://www.elastic.co/guide/en/observability/current/monitor-logs.html)
 to inspect all logs in one single place.
 
+`pino` 6.x, 7.x, and 8.x versions are supported.
+
 Please see the [Node.js ECS pino documentation](https://www.elastic.co/guide/en/ecs-logging/nodejs/current/pino.html).
 
 

--- a/packages/ecs-pino-format/package.json
+++ b/packages/ecs-pino-format/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js"
+    "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js",
+    "tav": "tav --quiet"
   },
   "engines": {
     "node": ">=10"
@@ -48,8 +49,10 @@
     "express": "^4.17.1",
     "pino": "^6.0.0",
     "pino-http": "^5.3.0",
+    "semver": "^7.5.4",
     "split2": "^3.1.1",
     "standard": "16.x",
-    "tap": "^15.0.10"
+    "tap": "^15.0.10",
+    "test-all-versions": "^5.0.1"
   }
 }

--- a/packages/ecs-pino-format/test/basic.test.js
+++ b/packages/ecs-pino-format/test/basic.test.js
@@ -25,6 +25,7 @@ const os = require('os')
 const addFormats = require('ajv-formats').default
 const Ajv = require('ajv').default
 const pino = require('pino')
+const semver = require('semver')
 const split = require('split2')
 const test = require('tap').test
 const ecsVersion = require('@elastic/ecs-helpers').version
@@ -319,6 +320,12 @@ test('can handle circular refs', t => {
 
   const rec = JSON.parse(lines[0])
   t.ok(validate(rec))
-  t.strictSame(rec.obj, { foo: 'bar', self: '[Circular]' })
+  if (semver.satisfies(pino.version, '>=7.0.0 <7.1.0')) {
+    // For some versions pino used json-stringify-safe with a slightly different
+    // serialization for circular refs.
+    t.strictSame(rec.obj, { foo: 'bar', self: '[Circular ~]' })
+  } else {
+    t.strictSame(rec.obj, { foo: 'bar', self: '[Circular]' })
+  }
   t.end()
 })

--- a/packages/ecs-winston-format/.tav.yml
+++ b/packages/ecs-winston-format/.tav.yml
@@ -1,0 +1,7 @@
+winston:
+  - versions: '>=3.0.0 <3.6.0'
+    node: '>=6.4.0'
+    commands: 'npm test'
+  - versions: '>=3.6.0'
+    node: '>=12'
+    commands: 'npm test'

--- a/packages/ecs-winston-format/README.md
+++ b/packages/ecs-winston-format/README.md
@@ -12,6 +12,8 @@ shipper, you can send your logs directly to Elasticsearch and leverage
 [Kibana's Logs app](https://www.elastic.co/guide/en/observability/current/monitor-logs.html)
 to inspect all logs in one single place.
 
+`winston` 3.x versions are supported.
+
 Please see the [Node.js ECS winston documentation](https://www.elastic.co/guide/en/ecs-logging/nodejs/current/winston.html).
 
 

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -33,7 +33,8 @@
     "bench": "./benchmarks/bench",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js"
+    "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js",
+    "tav": "tav --quiet"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
We support pino@6, pino@7, pino@8, and winston@3.

Refs: https://github.com/elastic/ecs-logging-nodejs/pull/131
Refs: https://github.com/elastic/ecs-logging-nodejs/issues/115

---

This adds "TAV" (test-all-versions) tests to test against supported versions of pino and winston. I didn't bother with morgan because there hasn't been a new release of it for years.  CI is setup to run this once per week.
