### PR TITLE
feat: separate winston ecsFormat to composable ecsFields and ecsStringify (take 2)

### DIFF
--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -26,18 +26,18 @@ $ npm install @elastic/ecs-winston-format
 
 [source,js]
 ----
-const winston = require('winston')
-const ecsFormat = require('@elastic/ecs-winston-format')
+const winston = require('winston');
+const { ecsFormat } = require('@elastic/ecs-winston-format');
 
 const logger = winston.createLogger({
   format: ecsFormat(/* options */), <1>
   transports: [
     new winston.transports.Console()
   ]
-})
+});
 
-logger.info('hi')
-logger.error('oops there is a problem', { err: new Error('boom') })
+logger.info('hi');
+logger.error('oops there is a problem', { err: new Error('boom') });
 ----
 <1> Pass the ECS formatter to winston here.
 
@@ -58,8 +58,8 @@ NOTE: You might like to try out our tutorial using Node.js ECS logging with wins
 
 [source,js]
 ----
-const winston = require('winston')
-const ecsFormat = require('@elastic/ecs-winston-format')
+const winston = require('winston');
+const { ecsFormat } = require('@elastic/ecs-winston-format');
 
 const logger = winston.createLogger({
   level: 'info',
@@ -67,10 +67,10 @@ const logger = winston.createLogger({
   transports: [
     new winston.transports.Console()
   ]
-})
+});
 
-logger.info('hi')
-logger.error('oops there is a problem', { foo: 'bar' })
+logger.info('hi');
+logger.error('oops there is a problem', { foo: 'bar' });
 ----
 <1> See available options <<winston-ref,below>>.
 
@@ -99,17 +99,17 @@ For https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-winston
 
 [source,js]
 ----
-const winston = require('winston')
-const ecsFormat = require('@elastic/ecs-winston-format')
+const winston = require('winston');
+const { ecsFormat } = require('@elastic/ecs-winston-format');
 const logger = winston.createLogger({
   format: ecsFormat(), <1>
   transports: [
     new winston.transports.Console()
   ]
-})
+});
 
-const myErr = new Error('boom')
-logger.info('oops', { err: myErr }) <2>
+const myErr = new Error('boom');
+logger.info('oops', { err: myErr }); <2>
 ----
 
 will yield (pretty-printed for readability):
@@ -153,9 +153,9 @@ objects when passed as the `req` and `res` meta fields, respectively.
 
 [source,js]
 ----
-const http = require('http')
-const winston = require('winston')
-const ecsFormat = require('@elastic/ecs-winston-format')
+const http = require('http');
+const winston = require('winston');
+const { ecsFormat } = require('@elastic/ecs-winston-format');
 
 const logger = winston.createLogger({
   level: 'info',
@@ -163,17 +163,17 @@ const logger = winston.createLogger({
   transports: [
     new winston.transports.Console()
   ]
-})
+});
 
-const server = http.createServer(handler)
+const server = http.createServer(handler);
 server.listen(3000, () => {
   logger.info('listening at http://localhost:3000')
-})
+});
 
 function handler (req, res) {
-  res.setHeader('Foo', 'Bar')
-  res.end('ok')
-  logger.info('handled request', { req, res }) <2>
+  res.setHeader('Foo', 'Bar');
+  res.end('ok');
+  logger.info('handled request', { req, res }); <2>
 }
 ----
 <1> use `convertReqRes` option
@@ -272,6 +272,18 @@ const logger = winston.createLogger({
 ----
 
 [float]
+[[winston-limitations]]
+=== Limitations and Considerations
+
+The https://github.com/elastic/ecs-logging/tree/main/spec[ecs-logging spec]
+suggests that the first three fields in log records should be `@timestamp`,
+`log.level`, and `message`. As of version 1.5.0, this formatter does *not*
+follow this suggestion. It would be possible but would require creating a new
+Object in `ecsFields` for each log record. Given that ordering of ecs-logging
+fields is for *human readability* and does not affect interoperability, the
+decision was made to prefer performance.
+
+[float]
 [[winston-ref]]
 === Reference
 
@@ -289,4 +301,49 @@ const logger = winston.createLogger({
 ** `serviceNodeName` +{type-string}+ A "service.node.name" value. If specified this overrides any value from an active APM agent.
 ** `eventDataset` +{type-string}+ A "event.dataset" value. If specified this overrides the default of using `${serviceVersion}`.
 
-Create a formatter for winston that emits in ECS Logging format.
+Create a formatter for winston that emits in ECS Logging format. This is a
+single format that handles both <<winston-ref-ecsFields>> and <<winston-ref-ecsStringify>>.
+The following two are equivalent:
+
+[source,js]
+----
+const { ecsFormat, ecsFields, ecsStringify } = require('@elastic/ecs-winston-format');
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  format: ecsFormat(/* options */),
+  // ...
+});
+
+const logger = winston.createLogger({
+  format: winston.format.combine(
+    ecsFields(/* options */),
+    ecsStringify()
+  ),
+  // ...
+});
+----
+
+[float]
+[[winston-ref-ecsFields]]
+==== `ecsFields([options])`
+
+* `options` +{type-object}+ The following options are supported:
+** `convertErr` +{type-boolean}+ Whether to convert a logged `err` field to ECS error fields. *Default:* `true`.
+** `convertReqRes` +{type-boolean}+ Whether to logged `req` and `res` HTTP request and response fields to ECS HTTP, User agent, and URL fields. *Default:* `false`.
+** `apmIntegration` +{type-boolean}+ Whether to enable APM agent integration. *Default:* `true`.
+** `serviceName` +{type-string}+ A "service.name" value. If specified this overrides any value from an active APM agent.
+** `serviceVersion` +{type-string}+ A "service.version" value. If specified this overrides any value from an active APM agent.
+** `serviceEnvironment` +{type-string}+ A "service.environment" value. If specified this overrides any value from an active APM agent.
+** `serviceNodeName` +{type-string}+ A "service.node.name" value. If specified this overrides any value from an active APM agent.
+** `eventDataset` +{type-string}+ A "event.dataset" value. If specified this overrides the default of using `${serviceVersion}`.
+
+Create a formatter for winston that converts fields on the log record info
+objecct to ECS Logging format.
+
+[float]
+[[winston-ref-ecsStringify]]
+==== `ecsStringify([options])`
+
+Create a formatter for winston that stringifies/serializes the log record to
+JSON. (This is very similar to `logform.json()`.)

--- a/packages/ecs-winston-format/CHANGELOG.md
+++ b/packages/ecs-winston-format/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+- Add `ecsFields` and `ecsStringify` exports that are winston formatters
+  that separate the gathering of ECS fields (`ecsFields`) and the
+  stringification of a log record to an ecs-logging JSON object
+  (`ecsStringify`). This allows for better composability using
+  [`winston.format.combine`](https://github.com/winstonjs/logform#combine).
+
+  The preferred way to import now changes to:
+
+  ```js
+  const { ecsFormat } = require('@elastic/ecs-winston-format'); // NEW
+  ```
+
+  The old way will be deprecated and removed in the future:
+
+  ```js
+  const ecsFormat = require('@elastic/ecs-winston-format'); // OLD
+  ```
+
+  Common usage will still use `ecsFormat` in the same way:
+
+  ```js
+  const { ecsFormat } = require('@elastic/ecs-winston-format');
+  const log = winston.createLogger({
+      format: ecsFormat(<options>),
+      // ...
+  ```
+
+  However, one can use the separated formatters as follows:
+
+  ```js
+  const { ecsFields, ecsStringify } = require('@elastic/ecs-winston-format');
+  const log = winston.createLogger({
+      format: winston.format.combine(
+          ecsFields(<options>),
+          // Add a custom formatter to redact fields here.
+          ecsStringify()
+      ),
+      // ...
+  ```
+
+  One good use case is for redaction of sensitive fields in the log record
+  as in https://github.com/elastic/ecs-logging-nodejs/issues/57. See a
+  complete example at [examples/redact-fields.js](./examples/redact-fields.js).
+
 - Fix/improve serialization of error details to `error.*` fields for the
   various ways a Winston logger handles `Error` instances.
 

--- a/packages/ecs-winston-format/README.md
+++ b/packages/ecs-winston-format/README.md
@@ -24,8 +24,8 @@ npm install @elastic/ecs-winston-format
 ## Usage
 
 ```js
-const winston = require('winston')
-const ecsFormat = require('@elastic/ecs-winston-format')
+const winston = require('winston');
+const { ecsFormat } = require('@elastic/ecs-winston-format');
 
 const logger = winston.createLogger({
   level: 'info',
@@ -33,10 +33,10 @@ const logger = winston.createLogger({
   transports: [
     new winston.transports.Console()
   ]
-})
+});
 
-logger.info('hi')
-logger.error('oops there is a problem', { foo: 'bar' })
+logger.info('hi');
+logger.error('oops there is a problem', { foo: 'bar' });
 ```
 
 Running this script will produce log output similar to the following:

--- a/packages/ecs-winston-format/examples/basic-without-ecs-format.js
+++ b/packages/ecs-winston-format/examples/basic-without-ecs-format.js
@@ -28,6 +28,7 @@ const logger = winston.createLogger({
   // winston format:
   format: winston.format.combine(
     winston.format.timestamp(),
+    winston.format.errors({stack: true, cause: true}),
     winston.format.json()
   ),
   transports: [
@@ -36,4 +37,8 @@ const logger = winston.createLogger({
 })
 
 logger.info('hi')
-logger.error('oops there is a problem', { foo: 'bar' })
+logger.warn('look out', { foo: 'bar' })
+
+const err = new Error('boom', { cause: new Error('the cause') })
+err.code = 42
+logger.error('here is an exception', err)

--- a/packages/ecs-winston-format/examples/basic.js
+++ b/packages/ecs-winston-format/examples/basic.js
@@ -18,13 +18,14 @@
 'use strict'
 
 const winston = require('winston')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 
 const logger = winston.createLogger({
   level: 'info',
   format: ecsFormat(),
-  // Compare to:
+  // Compare to the following (see "basic-without-ecs-format.js"):
   // format: winston.format.combine(
+  //   winston.format.timestamp(),
   //   winston.format.errors({stack: true, cause: true}),
   //   winston.format.json()
   // ),

--- a/packages/ecs-winston-format/examples/error.js
+++ b/packages/ecs-winston-format/examples/error.js
@@ -18,7 +18,7 @@
 'use strict'
 
 const winston = require('winston')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 
 const logger = winston.createLogger({
   level: 'info',

--- a/packages/ecs-winston-format/examples/express.js
+++ b/packages/ecs-winston-format/examples/express.js
@@ -20,7 +20,7 @@
 // This shows how one could use @elastic/ecs-winston-format with Express.
 // This implements simple Express middleware to do so.
 
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 const express = require('express')
 const winston = require('winston')
 

--- a/packages/ecs-winston-format/examples/http-with-elastic-apm.js
+++ b/packages/ecs-winston-format/examples/http-with-elastic-apm.js
@@ -38,7 +38,7 @@ const apm = require('elastic-apm-node').start({
 
 const http = require('http')
 const winston = require('winston')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 
 const logger = winston.createLogger({
   level: 'info',

--- a/packages/ecs-winston-format/examples/http.js
+++ b/packages/ecs-winston-format/examples/http.js
@@ -19,7 +19,7 @@
 
 const http = require('http')
 const winston = require('winston')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 
 const logger = winston.createLogger({
   level: 'info',

--- a/packages/ecs-winston-format/examples/redact-fields.js
+++ b/packages/ecs-winston-format/examples/redact-fields.js
@@ -1,0 +1,123 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+const http = require('http')
+const fastRedact = require('fast-redact')
+const winston = require('winston')
+const { ecsFields, ecsStringify } = require('../') // @elastic/ecs-winston-format
+
+// A formatter for Winston loggers to redact (obscure or remove) log record
+// fields.
+//
+// Usage:
+//   const log = winston.createLogger({
+//     format: winston.format.combine(
+//       // ...
+//       new WinstonRedactFormatter(<options>),
+//       // Some finalizing formatter, for example:
+//       //     winston.format.json()
+//     ),
+//     // ...
+//   })
+//
+// For example, if your log records include HTTP request headers at
+// "http.request.headers" and your services uses auth, you might want to
+// redact the "Authorization" header via:
+//
+//       new WinstonRedactFormatter({
+//         paths: ['http.request.headers.authorization']
+//       })
+//
+// This will result in log records looking like:
+//
+//       "request": {
+//         "method": "GET",
+//         "headers": {
+//           "authorization": "[REDACTED]",
+//
+// Options:
+// - opts.paths: An array of strings describe the location of keys per
+//   https://github.com/davidmarkclements/fast-redact#paths--array
+// - opts.censor: The replacement value, by default "[REDACTED]".
+//   Tip: use `censor: undefined` to have matching paths replaced with
+//   `undefined` which, if you use a JSON log output format, will result in
+//   matching paths being *removed*.
+class WinstonRedactFormatter {
+  constructor (opts) {
+    const fastRedactOpts = {
+      paths: opts.paths,
+      // This option tells fast-redact to just do the redactions in-place.
+      // Leave serialization to a separate Winston formatter.
+      serialize: false
+    }
+    if ('censor' in opts) {
+      fastRedactOpts.censor = opts.censor
+    }
+    this.redact = fastRedact(fastRedactOpts)
+  }
+
+  transform (info) {
+    this.redact(info)
+    return info
+  }
+}
+
+const log = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    ecsFields({ convertReqRes: true }),
+    new WinstonRedactFormatter({
+      paths: ['passwd', 'http.request.headers.authorization'],
+      // censor: '🙈'
+    }),
+    // Get *similar* results with winston.format.json().
+    ecsStringify()
+  ),
+  transports: [
+    new winston.transports.Console()
+  ]
+})
+
+const server = http.createServer(function handler (req, res) {
+  const body = JSON.stringify({ ping: 'pong' })
+  res.write(body)
+  res.end()
+  log.info('handled request', { req, res, passwd: 'sekrit' })
+})
+
+server.listen(3000, function () {
+  log.info('listening')
+  http.get('http://localhost:3000/', {
+    headers: {
+      Authorization: 'Bearer fuzzywuzzy'
+    }
+  }, function (res) {
+    const chunks = []
+    res.setEncoding('utf8')
+    res.on('data', function (c) {
+      chunks.push(c)
+    })
+    res.on('end', function () {
+      const body = chunks.join('')
+      log.info(`got ${res.statusCode} response`,
+        { headers: res.headers, body: body })
+      server.close()
+    })
+  })
+})

--- a/packages/ecs-winston-format/index.d.ts
+++ b/packages/ecs-winston-format/index.d.ts
@@ -47,5 +47,12 @@ interface Config {
 }
 
 declare function ecsFormat(opts?: Config): Logform.Format;
+declare function ecsFields(opts?: Config): Logform.Format;
+declare function ecsStringify(): Logform.Format;
 
-export = ecsFormat;
+export default ecsFormat;
+export {
+  ecsFormat,
+  ecsFields,
+  ecsStringify
+}

--- a/packages/ecs-winston-format/test/apm.test.js
+++ b/packages/ecs-winston-format/test/apm.test.js
@@ -127,7 +127,7 @@ test('tracing integration works', t => {
     }
     if (logObj) {
       t.ok(validate(logObj), 'logObj is ECS valid')
-      t.equal(ecsLoggingValidate(logObj), null, 'logObj is ecs-logging valid')
+      t.equal(ecsLoggingValidate(logObj, { ignoreIndex: true }), null, 'logObj is ecs-logging valid')
       logObjs.push(logObj)
       t.comment(`received logObjs ${logObjs.length}`)
     }
@@ -276,7 +276,7 @@ test('apmIntegration=false disables tracing integration', t => {
     }
     if (logObj) {
       t.ok(validate(logObj), 'logObj is ECS valid')
-      t.equal(ecsLoggingValidate(logObj), null, 'logObj is ecs-logging valid')
+      t.equal(ecsLoggingValidate(logObj, { ignoreIndex: true }), null, 'logObj is ecs-logging valid')
       logObjs.push(logObj)
       t.comment(`received logObjs ${logObjs.length}`)
     }

--- a/packages/ecs-winston-format/test/errors.test.js
+++ b/packages/ecs-winston-format/test/errors.test.js
@@ -27,7 +27,7 @@ const winston = require('winston')
 const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
 const { validate, CaptureTransport } = require('./utils')
 
-const ecsFormat = require('../')
+const { ecsFormat } = require('../')
 
 // https://nodejs.org/en/blog/release/v16.9.0
 const IS_ERROR_CAUSE_SUPPORTED = semver.satisfies(process.version, '>=16.9.0')
@@ -49,7 +49,7 @@ test('log.info("msg", new Error("boom"))', t => {
 
   const rec = cap.records[0]
   t.ok(validate(rec))
-  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE], { ignoreIndex: true }), null)
   t.equal(rec.message, 'msg boom') // Winston core appends the err.message to the message.
   // Ideally we'd expect `aField: 'defaultMeta field value'`, but Winston
   // core error handling overwrites with `err.aField`. The ECS formatter
@@ -130,14 +130,14 @@ test('log.info(new Error("boom"))', t => {
 
   const rec = cap.records[0]
   t.ok(validate(rec))
-  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE], { ignoreIndex: true }), null)
   t.equal(rec.message, 'boom', 'message')
   t.equal(rec.aField, 'defaultMeta field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
   t.equal(rec.error.message, 'boom', 'error.message')
   t.match(rec.error.stack_trace, /^Error: boom\n {4}at/, 'error.stack_trace')
   // Winston mixes `err` properties and `defaultMeta` at the top-level, so
-  // conflicts result in lost date.
+  // conflicts result in lost data.
   t.equal(rec.error.aField, 'defaultMeta field value', 'error.aField')
   if (IS_ERROR_CAUSE_SUPPORTED) {
     t.equal(rec.error.cause, 'the cause is a string', 'error.cause')
@@ -160,7 +160,7 @@ test('log.info(new Error("boom"), {...})', t => {
 
   const rec = cap.records[0]
   t.ok(validate(rec))
-  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE], { ignoreIndex: true }), null)
   t.equal(rec.message, 'boom', 'message')
   t.equal(rec.aField, 'splat field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
@@ -188,7 +188,7 @@ test('log.info(new Error("")) with empty err.message', t => {
 
   const rec = cap.records[0]
   t.ok(validate(rec))
-  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE], { ignoreIndex: true }), null)
   t.equal(rec.message, '', 'message')
   t.equal(rec.aField, 'defaultMeta field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')
@@ -216,7 +216,7 @@ test('log.info("msg", { err: new Error("boom") })', t => {
 
   const rec = cap.records[0]
   t.ok(validate(rec))
-  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE]), null)
+  t.equal(ecsLoggingValidate(cap.infos[0][MESSAGE], { ignoreIndex: true }), null)
   t.equal(rec.message, 'msg', 'message')
   t.equal(rec.aField, 'splat field value', 'aField')
   t.equal(rec.error.type, 'Error', 'error.type')

--- a/packages/ecs-winston-format/test/serve-one-http-req-with-apm.js
+++ b/packages/ecs-winston-format/test/serve-one-http-req-with-apm.js
@@ -41,7 +41,7 @@ const apm = require('elastic-apm-node').start({
 })
 
 const http = require('http')
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
 const ecsOpts = {

--- a/packages/ecs-winston-format/test/simple-log-hi.js
+++ b/packages/ecs-winston-format/test/simple-log-hi.js
@@ -19,7 +19,7 @@
 
 // This script is used by "apm.test.js".
 
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
 const log = winston.createLogger({

--- a/packages/ecs-winston-format/test/uncaught-exception.js
+++ b/packages/ecs-winston-format/test/uncaught-exception.js
@@ -17,7 +17,7 @@
 
 'use strict'
 
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
 // eslint-disable-next-line

--- a/packages/ecs-winston-format/test/unhandled-rejection.js
+++ b/packages/ecs-winston-format/test/unhandled-rejection.js
@@ -17,7 +17,7 @@
 
 'use strict'
 
-const ecsFormat = require('../') // @elastic/ecs-winston-format
+const { ecsFormat } = require('../') // @elastic/ecs-winston-format
 const winston = require('winston')
 
 // eslint-disable-next-line


### PR DESCRIPTION
Fixes: #57
Obsoletes: #65

---

This basically modernizes (for changes in this package) and finishes #57. I'm thankful to @lancegliser for all the assistance. The best description is in the CHANGELOG.md addition and the "packages/ecs-winston-format/examples/redact-fields.js" example showing the use case.