### PR TITLE
test: fix winston TAV tests, raise min-supported Winston to 3.3.3

### DIFF
--- a/docs/winston.asciidoc
+++ b/docs/winston.asciidoc
@@ -5,7 +5,7 @@ This Node.js package provides a formatter for the https://github.com/winstonjs/w
 logger, compatible with {ecs-logging-ref}/intro.html[Elastic Common Schema (ECS) logging].
 In combination with the https://www.elastic.co/beats/filebeat[Filebeat] shipper,
 you can https://www.elastic.co/log-monitoring[monitor all your logs] in one
-place in the Elastic Stack. `winston` 3.x versions are supported.
+place in the Elastic Stack. `winston` 3.x versions >=3.3.3 are supported.
 
 
 [float]

--- a/packages/ecs-winston-format/.tav.yml
+++ b/packages/ecs-winston-format/.tav.yml
@@ -1,4 +1,6 @@
-# Skip winston@3.7.1, it breaks errors.test.js. Fixed in 3.7.2.
+# - Skip winston@3.7.1, it breaks errors.test.js. Fixed in 3.7.2.
+# - Min supported is winston@3.3.3, because I had timeouts even installing
+#   winston@3.3.1 with node v14.
 winston:
   - versions: '>=3.3.3 <3.6.0'
     node: '>=6.4.0'

--- a/packages/ecs-winston-format/.tav.yml
+++ b/packages/ecs-winston-format/.tav.yml
@@ -1,7 +1,8 @@
+# Skip winston@3.7.1, it breaks errors.test.js. Fixed in 3.7.2.
 winston:
-  - versions: '>=3.0.0 <3.6.0'
+  - versions: '>=3.3.3 <3.6.0'
     node: '>=6.4.0'
     commands: 'npm test'
-  - versions: '>=3.6.0'
+  - versions: '>=3.6.0 <3.7.1 || >3.7.1'
     node: '>=12'
     commands: 'npm test'

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -54,6 +54,7 @@
     "split2": "^3.2.2",
     "standard": "16.x",
     "tap": "^15.0.10",
+    "test-all-versions": "^5.0.1",
     "winston": "^3.3.3"
   }
 }


### PR DESCRIPTION
The version specifier was originally 3.3.3 and now I wonder if that
was for a good reason. While attempting to TAV test with node v14
I get timeouts attempting to install winston@3.3.1.