### PR TITLE
feat: support multiple import styles from JS and TS; add morgan types

### DIFF
--- a/docs/morgan.asciidoc
+++ b/docs/morgan.asciidoc
@@ -28,17 +28,17 @@ $ npm install @elastic/ecs-morgan-format
 
 [source,js]
 ----
-const app = require('express')()
-const morgan = require('morgan')
-const ecsFormat = require('@elastic/ecs-morgan-format')
+const app = require('express')();
+const morgan = require('morgan');
+const { ecsFormat } = require('@elastic/ecs-morgan-format');
 
-app.use(morgan(ecsFormat(/* options */))) <1>
+app.use(morgan(ecsFormat(/* options */))); <1>
 
 // ...
 app.get('/', function (req, res) {
-  res.send('hello, world!')
+  res.send('hello, world!');
 })
-app.listen(3000)
+app.listen(3000);
 ----
 <1> Pass the ECS formatter to `morgan()`.
 
@@ -58,17 +58,17 @@ include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]
 
 [source,js]
 ----
-const app = require('express')()
-const morgan = require('morgan')
-const ecsFormat = require('@elastic/ecs-morgan-format')
+const app = require('express')();
+const morgan = require('morgan');
+const { ecsFormat } = require('@elastic/ecs-morgan-format');
 
-app.use(morgan(ecsFormat(/* options */))) <1>
+app.use(morgan(ecsFormat(/* options */))); <1>
 
 app.get('/', function (req, res) {
-  res.send('hello, world!')
+  res.send('hello, world!');
 })
 app.get('/error', function (req, res, next) {
-  next(new Error('boom'))
+  next(new Error('boom'));
 })
 
 app.listen(3000)
@@ -129,11 +129,11 @@ specified format. The default is https://github.com/expressjs/morgan#combined[`c
 
 [source,js]
 ----
-const app = require('express')()
-const morgan = require('morgan')
-const ecsFormat = require('@elastic/ecs-morgan-format')
+const app = require('express')();
+const morgan = require('morgan');
+const { ecsFormat } = require('@elastic/ecs-morgan-format');
 
-app.use(morgan(ecsFormat({ format: 'tiny' }))) <1>
+app.use(morgan(ecsFormat({ format: 'tiny' }))); <1>
 // ...
 ----
 <1> If "format" is the only option you are using, you may pass it as `ecsFormat('tiny')`.
@@ -201,7 +201,7 @@ Integration with Elastic APM can be explicitly disabled via the
 
 [source,js]
 ----
-app.use(morgan(ecsFormat({ apmIntegration: false })))
+app.use(morgan(ecsFormat({ apmIntegration: false })));
 ----
 
 

--- a/docs/pino.asciidoc
+++ b/docs/pino.asciidoc
@@ -26,12 +26,12 @@ $ npm install @elastic/ecs-pino-format
 
 [source,js]
 ----
-const ecsFormat = require('@elastic/ecs-pino-format')
-const pino = require('pino')
+const { ecsFormat } = require('@elastic/ecs-pino-format');
+const pino = require('pino');
 
-const log = pino(ecsFormat(/* options */)) <1>
-log.info('hi')
-log.error({ err: new Error('boom') }, 'oops there is a problem')
+const log = pino(ecsFormat(/* options */)); <1>
+log.info('hi');
+log.error({ err: new Error('boom') }, 'oops there is a problem');
 // ...
 ----
 <1> This will https://getpino.io/#/docs/api?id=options[configure] Pino's `formatters`, `messageKey` and `timestamp` options.
@@ -53,14 +53,14 @@ include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]
 
 [source,js]
 ----
-const ecsFormat = require('@elastic/ecs-pino-format')
-const pino = require('pino')
+const { ecsFormat } = require('@elastic/ecs-pino-format');
+const pino = require('pino');
 
-const log = pino(ecsFormat(/* options */)) <1>
-log.info('Hello world')
+const log = pino(ecsFormat(/* options */)); <1>
+log.info('Hello world');
 
-const child = log.child({ module: 'foo' })
-child.warn('From child')
+const child = log.child({ module: 'foo' });
+child.warn('From child');
 ----
 <1> See available options <<pino-ref,below>>.
 
@@ -82,12 +82,12 @@ For example:
 
 [source,js]
 ----
-const ecsFormat = require('@elastic/ecs-pino-format')
-const pino = require('pino')
-const log = pino(ecsFormat())
+const { ecsFormat } = require('@elastic/ecs-pino-format');
+const pino = require('pino');
+const log = pino(ecsFormat());
 
-const myErr = new Error('boom')
-log.info({ err: myErr }, 'oops')
+const myErr = new Error('boom');
+log.info({ err: myErr }, 'oops');
 ----
 
 will yield (pretty-printed for readability):
@@ -114,7 +114,7 @@ Special handling of the `err` field can be disabled via the `convertErr: false` 
 
 [source,js]
 ----
-const log = pino(ecsFormat({ convertErr: false }))
+const log = pino(ecsFormat({ convertErr: false }));
 ----
 
 
@@ -130,20 +130,20 @@ objects when passed as the `req` and `res` fields, respectively.
 
 [source,js]
 ----
-const http = require('http')
-const ecsFormat = require('@elastic/ecs-pino-format')
-const pino = require('pino')
+const http = require('http');
+const { ecsFormat } = require('@elastic/ecs-pino-format');
+const pino = require('pino');
 
-const log = pino(ecsFormat({ convertReqRes: true })) <1>
+const log = pino(ecsFormat({ convertReqRes: true })); <1>
 
 const server = http.createServer(function handler (req, res) {
-  res.setHeader('Foo', 'Bar')
-  res.end('ok')
-  log.info({ req, res }, 'handled request') <2>
-})
+  res.setHeader('Foo', 'Bar');
+  res.end('ok');
+  log.info({ req, res }, 'handled request'); <2>
+});
 
 server.listen(3000, () => {
-  log.info('listening at http://localhost:3000')
+  log.info('listening at http://localhost:3000');
 }
 ----
 <1> use `convertReqRes` option
@@ -243,7 +243,7 @@ Integration with Elastic APM can be explicitly disabled via the
 
 [source,js]
 ----
-const log = pino(ecsFormat({ apmIntegration: false }))
+const log = pino(ecsFormat({ apmIntegration: false }));
 ----
 
 

--- a/packages/ecs-morgan-format/CHANGELOG.md
+++ b/packages/ecs-morgan-format/CHANGELOG.md
@@ -8,6 +8,26 @@
 
 - Set `http.request.id` field (see [ecs-helpers CHANGELOG](../ecs-helpers/CHANGELOG.md#v210)).
 
+- Changed to a named export. The preferred way to import is now:
+
+  ```js
+  const { ecsFormat } = require('@elastic/ecs-morgan-format'); // CommonJS
+  import { ecsFormat } from '@elastic/ecs-morgan-format'; // ESM
+  ```
+
+  The old way will be deprecated and removed in the future:
+
+  ```js
+  const ecsFormat = require('@elastic/ecs-morgan-format'); // OLD
+  ```
+
+  Changes in this version add support for default import in TypeScript, with or
+  without the `esModuleInterop` setting:
+
+  ```ts
+  import ecsFormat from '@elastic/ecs-morgan-format';
+  ```
+
 ## v1.4.0
 
 - Add `service.version`, `service.environment`, and `service.node.name` log

--- a/packages/ecs-morgan-format/README.md
+++ b/packages/ecs-morgan-format/README.md
@@ -27,7 +27,7 @@ npm install @elastic/ecs-morgan-format
 ```js
 const app = require('express')()
 const morgan = require('morgan')
-const ecsFormat = require('@elastic/ecs-morgan-format')
+const { ecsFormat } = require('@elastic/ecs-morgan-format')
 
 app.use(morgan(ecsFormat(/* options */)))
 

--- a/packages/ecs-morgan-format/examples/express-with-apm.js
+++ b/packages/ecs-morgan-format/examples/express-with-apm.js
@@ -38,7 +38,7 @@ const apm = require('elastic-apm-node').start({
 
 const app = require('express')()
 const morgan = require('morgan')
-const ecsFormat = require('../') // @elastic/ecs-morgan-format
+const { ecsFormat } = require('../') // @elastic/ecs-morgan-format
 
 app.use(morgan(ecsFormat()))
 

--- a/packages/ecs-morgan-format/examples/express.js
+++ b/packages/ecs-morgan-format/examples/express.js
@@ -19,7 +19,7 @@
 
 const app = require('express')()
 const morgan = require('morgan')
-const ecsFormat = require('../') // @elastic/ecs-morgan-format
+const { ecsFormat } = require('../') // @elastic/ecs-morgan-format
 
 app.use(morgan(ecsFormat()))
 

--- a/packages/ecs-morgan-format/index.d.ts
+++ b/packages/ecs-morgan-format/index.d.ts
@@ -1,18 +1,14 @@
-import type { LoggerOptions } from "pino";
+import type { FormatFn } from "morgan";
 
 interface Config {
   /**
-   * Whether to convert a logged `err` field to ECS error fields.
-   * Default true, to match Pino's default of having an `err` serializer.
+   * A format *name* (e.g. 'combined'), format function (e.g. `morgan.combined`),
+   * or a format string (e.g. ':method :url :status').
+   *
+   * This is used to format the "message" field.
+   * @default `morgan.combined`
    */
-
-  convertErr?: boolean;
-  /**
-   * Whether to convert logged `req` and `res` HTTP request and response fields
-   * to ECS HTTP, User agent, and URL fields. Default false.
-   */
-
-  convertReqRes?: boolean;
+  format: string;
 
   /**
    * Whether to automatically integrate with
@@ -31,7 +27,7 @@ interface Config {
    * - "service.node.name" - the configured `serviceNodeName` in the agent
    * - "event.dataset" - set to `${serviceName}` for correlation in Kibana
    *
-   * Default true.
+   * @default true.
    */
   apmIntegration?: boolean;
 
@@ -48,7 +44,7 @@ interface Config {
 
 }
 
-declare function ecsFormat(config?: Config): LoggerOptions;
+declare function ecsFormat(config?: Config): FormatFn;
 
 export default ecsFormat;
 export { ecsFormat }

--- a/packages/ecs-morgan-format/index.js
+++ b/packages/ecs-morgan-format/index.js
@@ -179,4 +179,8 @@ function ecsFormat (opts) {
   }
 }
 
+// For backwards compatibility with v1.0.0, the top-level export is `ecsFormat`,
+// though using the named export is preferred.
 module.exports = ecsFormat
+module.exports.ecsFormat = ecsFormat
+module.exports.default = ecsFormat

--- a/packages/ecs-morgan-format/package.json
+++ b/packages/ecs-morgan-format/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "A formatter for the morgan logger compatible with Elastic Common Schema.",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js"
   ],

--- a/packages/ecs-morgan-format/test/basic.test.js
+++ b/packages/ecs-morgan-format/test/basic.test.js
@@ -26,7 +26,7 @@ const morgan = require('morgan')
 const split = require('split2')
 const test = require('tap').test
 
-const ecsFormat = require('../')
+const { ecsFormat } = require('../')
 const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
 
 const ajv = new Ajv({

--- a/packages/ecs-morgan-format/test/serve-one-http-req-with-apm.js
+++ b/packages/ecs-morgan-format/test/serve-one-http-req-with-apm.js
@@ -44,7 +44,7 @@ const apm = require('elastic-apm-node').start({
 const app = require('express')()
 const http = require('http')
 const morgan = require('morgan')
-const ecsFormat = require('../') // @elastic/ecs-morgan-format
+const { ecsFormat } = require('../') // @elastic/ecs-morgan-format
 
 const ecsOpts = { serviceVersion: 'override-serviceVersion' }
 if (disableApmIntegration) {

--- a/packages/ecs-pino-format/CHANGELOG.md
+++ b/packages/ecs-pino-format/CHANGELOG.md
@@ -8,6 +8,26 @@
 
 - Set `http.request.id` field (see [ecs-helpers CHANGELOG](../ecs-helpers/CHANGELOG.md#v210)).
 
+- Changed to a named export. The preferred way to import is now:
+
+  ```js
+  const { ecsFormat } = require('@elastic/ecs-pino-format'); // CommonJS
+  import { ecsFormat } from '@elastic/ecs-pino-format'; // ESM
+  ```
+
+  The old way will be deprecated and removed in the future:
+
+  ```js
+  const ecsFormat = require('@elastic/ecs-pino-format'); // OLD
+  ```
+
+  Changes in this version add support for default import in TypeScript,
+  with or without the `esModuleInterop` setting:
+
+  ```ts
+  import ecsFormat from '@elastic/ecs-pino-format';
+  ```
+
 ## v1.4.0
 
 - Add `service.version`, `service.environment`, and `service.node.name` log

--- a/packages/ecs-pino-format/README.md
+++ b/packages/ecs-pino-format/README.md
@@ -28,7 +28,7 @@ npm install @elastic/ecs-pino-format
 This package will configure Pino's `formatters`, `messageKey` and `timestamp` options.
 
 ```js
-const ecsFormat = require('@elastic/ecs-pino-format')
+const { ecsFormat } = require('@elastic/ecs-pino-format')
 const pino = require('pino')
 
 const log = pino(ecsFormat(/* options */))

--- a/packages/ecs-pino-format/examples/basic.js
+++ b/packages/ecs-pino-format/examples/basic.js
@@ -17,7 +17,7 @@
 
 'use strict'
 
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
 const log = pino(ecsFormat())

--- a/packages/ecs-pino-format/examples/error.js
+++ b/packages/ecs-pino-format/examples/error.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-const ecsFormat = require('..') // @elastic/ecs-pino-format
+const { ecsFormat } = require('..') // @elastic/ecs-pino-format
 const pino = require('pino')
 const log = pino({ ...ecsFormat() })
 

--- a/packages/ecs-pino-format/examples/express-simple.js
+++ b/packages/ecs-pino-format/examples/express-simple.js
@@ -20,7 +20,7 @@
 // This shows how one could use @elastic/ecs-pino-format with Express.
 // This implements simple Express middleware to do so.
 
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const express = require('express')
 const pino = require('pino')
 

--- a/packages/ecs-pino-format/examples/express-with-pino-http.js
+++ b/packages/ecs-pino-format/examples/express-with-pino-http.js
@@ -23,7 +23,7 @@
 // TODO: doc the log.child({req}) limitation
 // TODO: doc pino-http's 'req.id' and ECS translation to 'event.id'
 
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const express = require('express')
 const pino = require('pino')
 const pinoHttp = require('pino-http')

--- a/packages/ecs-pino-format/examples/http-with-elastic-apm.js
+++ b/packages/ecs-pino-format/examples/http-with-elastic-apm.js
@@ -38,7 +38,7 @@ const apm = require('elastic-apm-node').start({
 
 const http = require('http')
 const https = require('https')
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
 const log = pino({ ...ecsFormat({ convertReqRes: true }) })

--- a/packages/ecs-pino-format/examples/http.js
+++ b/packages/ecs-pino-format/examples/http.js
@@ -18,7 +18,7 @@
 'use strict'
 
 const http = require('http')
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
 const log = pino({ ...ecsFormat({ convertReqRes: true }) })

--- a/packages/ecs-pino-format/index.js
+++ b/packages/ecs-pino-format/index.js
@@ -32,7 +32,7 @@ let elasticApm = null
  *
  * @param {Config} [opts] - See index.d.ts.
  */
-function createEcsPinoOptions (opts) {
+function ecsFormat (opts) {
   // istanbul ignore next
   opts = opts || {}
   const convertErr = opts.convertErr != null ? opts.convertErr : true
@@ -211,4 +211,18 @@ function createEcsPinoOptions (opts) {
   return ecsPinoOptions
 }
 
-module.exports = createEcsPinoOptions
+// Exports to support the following import-styles from JS and TS code:
+// 1. `const { ecsFormat } = require('@elastic/ecs-pino-format)` in JS and TS.
+//    The preferred import style for JS code using CommonJS.
+// 2. `import { ecsFormat } from '@elastic/ecs-pino-format'` in JS and TS.
+//    ES module (ESM) import style. This is the preferred style for TypeScript
+//    code and for JS developers using ESM.
+// 3. `const ecsFormat = require('@elastic/ecs-pino-format')` in JS.
+//    The old, deprecated import method. Still supported for backward compat.
+// 4. `import ecsFormat from '@elastic/ecs-pino-format'` in JS and TS.
+//    This works, but is deprecated. Prefer #2 style.
+// 5. `import * as EcsPinoFormat from '@elastic/ecs-pino-format'` in TS.
+//    One must then use `EcsPinoFormat.ecsFormat()`.
+module.exports = ecsFormat // Required to support style 3.
+module.exports.ecsFormat = ecsFormat
+module.exports.default = ecsFormat // Required to support style 4.

--- a/packages/ecs-pino-format/package.json
+++ b/packages/ecs-pino-format/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js",
+    "test": "tap --timeout ${TAP_TIMEOUT:-30} test/*.test.js",
+    "test:skip-slow": "TEST_SKIP_SLOW=1 tap --no-coverage --timeout ${TAP_TIMEOUT:-10} test/*.test.js # test a subset for a fast test run",
     "tav": "tav --quiet"
   },
   "engines": {
@@ -47,12 +48,14 @@
     "ajv-formats": "^1.5.1",
     "elastic-apm-node": "^3.23.0",
     "express": "^4.17.1",
+    "glob": "^7.2.3",
     "pino": "^6.0.0",
     "pino-http": "^5.3.0",
     "semver": "^7.5.4",
     "split2": "^3.1.1",
     "standard": "16.x",
     "tap": "^15.0.10",
-    "test-all-versions": "^5.0.1"
+    "test-all-versions": "^5.0.1",
+    "ts-node": "^10.9.1"
   }
 }

--- a/packages/ecs-pino-format/test/basic.test.js
+++ b/packages/ecs-pino-format/test/basic.test.js
@@ -30,7 +30,7 @@ const split = require('split2')
 const test = require('tap').test
 const ecsVersion = require('@elastic/ecs-helpers').version
 
-const ecsFormat = require('../')
+const { ecsFormat } = require('../')
 const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
 
 const ajv = new Ajv({

--- a/packages/ecs-pino-format/test/fixtures/js-esm-import.mjs
+++ b/packages/ecs-pino-format/test/fixtures/js-esm-import.mjs
@@ -1,0 +1,4 @@
+import { ecsFormat } from '../../index.js'
+import pino from 'pino'
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/js-require-default.js
+++ b/packages/ecs-pino-format/test/fixtures/js-require-default.js
@@ -1,0 +1,5 @@
+// The old way to import @elastic/ecs-pino-format, support for backward compat.
+const ecsFormat = require('../../')
+const pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/js-require-named.js
+++ b/packages/ecs-pino-format/test/fixtures/js-require-named.js
@@ -1,0 +1,5 @@
+// The new way to import @elastic/ecs-pino-format.
+const { ecsFormat } = require('../../')
+const pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/ts-import-default.ts
+++ b/packages/ecs-pino-format/test/fixtures/ts-import-default.ts
@@ -1,0 +1,4 @@
+import ecsFormat from '../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/ts-import-named.ts
+++ b/packages/ecs-pino-format/test/fixtures/ts-import-named.ts
@@ -1,0 +1,4 @@
+import { ecsFormat } from '../../'
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/ts-import-star.ts
+++ b/packages/ecs-pino-format/test/fixtures/ts-import-star.ts
@@ -1,0 +1,4 @@
+import * as EcsPinoFormat from '../../'
+import pino = require('pino')
+const log = pino(EcsPinoFormat.ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/ts-require.ts
+++ b/packages/ecs-pino-format/test/fixtures/ts-require.ts
@@ -1,0 +1,4 @@
+const { ecsFormat } = require('../../')
+import pino = require('pino')
+const log = pino(ecsFormat())
+log.info('hi')

--- a/packages/ecs-pino-format/test/fixtures/tsconfig-esModuleInterop.json
+++ b/packages/ecs-pino-format/test/fixtures/tsconfig-esModuleInterop.json
@@ -1,0 +1,17 @@
+// TypeScript using esModuleInterop:true (the default setting from `tsc --init`).
+// Based on https://github.com/tsconfig/bases/blob/main/bases/node10.json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 10",
+
+  "compilerOptions": {
+    "lib": ["es2018"],
+    "module": "commonjs",
+    "target": "es2018",
+
+    "strict": true,
+    "esModuleInterop": true, // XXX
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/packages/ecs-pino-format/test/fixtures/tsconfig-no-esModuleInterop.json
+++ b/packages/ecs-pino-format/test/fixtures/tsconfig-no-esModuleInterop.json
@@ -1,0 +1,16 @@
+// Based on https://github.com/tsconfig/bases/blob/main/bases/node10.json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 10",
+
+  "compilerOptions": {
+    "lib": ["es2018"],
+    "module": "commonjs",
+    "target": "es2018",
+
+    "strict": true,
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/packages/ecs-pino-format/test/import-styles.test.js
+++ b/packages/ecs-pino-format/test/import-styles.test.js
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+'use strict'
+
+// Test all the supported import styles: for CommonJS, ESM, and TypeScript.
+// Each case is a JS or TS file in "test/fixtures/...".
+//
+// Note that we intentionally do NOT support the TypeScript-only
+// `import ecsFormat = require('...')` format
+// (https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
+
+const addFormats = require('ajv-formats').default
+const Ajv = require('ajv').default
+const { execFile, execSync } = require('child_process')
+const glob = require('glob')
+const path = require('path')
+const semver = require('semver')
+const test = require('tap').test
+
+const { ecsLoggingValidate } = require('../../../utils/lib/ecs-logging-validate')
+
+const ajv = new Ajv({
+  allErrors: true,
+  verbose: true
+})
+addFormats(ajv)
+const validate = ajv.compile(require('../../../utils/schema.json'))
+
+const TS_NODE = execSync('npm exec which ts-node').toString().trim()
+const IS_TSC_SUPPORTED = semver.satisfies(process.version, '>=14.17')
+const IS_ESM_SUPPORTED = semver.satisfies(process.version, '>=12')
+const TEST_SKIP_SLOW = ['1', 'true'].includes(process.env.TEST_SKIP_SLOW)
+
+test('import styles', suite => {
+  const importCases = [
+    { file: 'fixtures/js-require-default.js' },
+    { file: 'fixtures/js-require-named.js' },
+    {
+      file: 'fixtures/js-esm-import.mjs',
+      testOpts: {
+        skip: !IS_ESM_SUPPORTED ? `ESM named import does not support node ${process.version}` : false
+      }
+    }
+  ]
+  if (!TEST_SKIP_SLOW) {
+    // Run each of the *.ts files with each of the tsconfig-*.json files
+    const TSCONFIGS = glob.sync(path.join(__dirname, '/fixtures/tsconfig-*.json'))
+    const TSSCRIPTS = glob.sync(path.join(__dirname, '/fixtures/*.ts'))
+    for (const tsconfig of TSCONFIGS) {
+      for (const tsscript of TSSCRIPTS) {
+        importCases.push({
+          exec: TS_NODE,
+          opts: ['-P', path.relative(__dirname, tsconfig)],
+          file: path.relative(__dirname, tsscript),
+          testOpts: {
+            skip: !IS_TSC_SUPPORTED ? `tsc@5 does not support node ${process.version}` : false
+          }
+        })
+      }
+    }
+  }
+
+  importCases.forEach((ic) => {
+    const exec = ic.exec || process.execPath
+    const args = (ic.opts ? ic.opts.slice() : []).concat([ic.file])
+    const summary = `${path.basename(exec)} ${args.join(' ')}`
+
+    suite.test(summary, ic.testOpts || {}, t => {
+      execFile(
+        exec,
+        args,
+        {
+          cwd: __dirname,
+          timeout: 5000 // A guard in case the script hangs.
+        },
+        function (err, stdout, stderr) {
+          t.error(err, 'script exited successfully')
+          const rec = JSON.parse(stdout)
+          t.ok(rec, 'got a single log record')
+          t.equal(rec.message, 'hi', 'log message is "hi"')
+          t.ok(validate(rec), 'rec is valid')
+          t.equal(ecsLoggingValidate(stdout, { ignoreIndex: true }), null)
+          t.end()
+        }
+      )
+    })
+  })
+
+  suite.end()
+})

--- a/packages/ecs-pino-format/test/serve-one-http-req-with-apm.js
+++ b/packages/ecs-pino-format/test/serve-one-http-req-with-apm.js
@@ -41,7 +41,7 @@ const apm = require('elastic-apm-node').start({
 })
 
 const http = require('http')
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
 const ecsOpts = {

--- a/packages/ecs-pino-format/test/simple-log-hi.js
+++ b/packages/ecs-pino-format/test/simple-log-hi.js
@@ -19,7 +19,7 @@
 
 // This script is used by "apm.test.js".
 
-const ecsFormat = require('../') // @elastic/ecs-pino-format
+const { ecsFormat } = require('../') // @elastic/ecs-pino-format
 const pino = require('pino')
 
 const log = pino(ecsFormat())

--- a/packages/ecs-winston-format/CHANGELOG.md
+++ b/packages/ecs-winston-format/CHANGELOG.md
@@ -11,7 +11,8 @@
   The preferred way to import now changes to:
 
   ```js
-  const { ecsFormat } = require('@elastic/ecs-winston-format'); // NEW
+  const { ecsFormat } = require('@elastic/ecs-winston-format'); // CommonJS
+  import { ecsFormat } from '@elastic/ecs-winston-format'; // ESM
   ```
 
   The old way will be deprecated and removed in the future:
@@ -20,23 +21,23 @@
   const ecsFormat = require('@elastic/ecs-winston-format'); // OLD
   ```
 
-  Common usage will still use `ecsFormat` in the same way:
+  Typical usage of `ecsFormat` is unchanged:
 
   ```js
   const { ecsFormat } = require('@elastic/ecs-winston-format');
   const log = winston.createLogger({
-      format: ecsFormat(<options>),
+      format: ecsFormat(/* options */),
       // ...
   ```
 
-  However, one can use the separated formatters as follows:
+  However, one can now use the separated formatters as follows:
 
   ```js
   const { ecsFields, ecsStringify } = require('@elastic/ecs-winston-format');
   const log = winston.createLogger({
       format: winston.format.combine(
-          ecsFields(<options>),
-          // Add a custom formatter to redact fields here.
+          ecsFields(/* options */),
+          // Add any custom formatters, e.g. one to redact added ECS fields.
           ecsStringify()
       ),
       // ...

--- a/packages/ecs-winston-format/index.js
+++ b/packages/ecs-winston-format/index.js
@@ -321,8 +321,9 @@ function ecsFormat (opts) {
 }
 
 // For backwards compatibility with v1.0.0, the top-level export is `ecsFormat`,
-// though using the separate exports is preferred.
+// though using the named exports is preferred.
 module.exports = ecsFormat
 module.exports.ecsFormat = ecsFormat
 module.exports.ecsFields = ecsFields
 module.exports.ecsStringify = ecsStringify
+module.exports.default = ecsFormat

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -34,6 +34,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test": "tap --timeout ${TAP_TIMEOUT:-10} test/*.test.js",
+    "test:skip-slow": "TEST_SKIP_SLOW=1 tap --no-coverage --timeout ${TAP_TIMEOUT:-10} test/*.test.js # test a subset for a fast test run",
     "tav": "tav --quiet"
   },
   "engines": {

--- a/packages/ecs-winston-format/test/errors.test.js
+++ b/packages/ecs-winston-format/test/errors.test.js
@@ -32,6 +32,8 @@ const { ecsFormat } = require('../')
 // https://nodejs.org/en/blog/release/v16.9.0
 const IS_ERROR_CAUSE_SUPPORTED = semver.satisfies(process.version, '>=16.9.0')
 
+const TEST_SKIP_SLOW = ['1', 'true'].includes(process.env.TEST_SKIP_SLOW)
+
 test('log.info("msg", new Error("boom"))', t => {
   const cap = new CaptureTransport()
   const log = winston.createLogger({
@@ -65,55 +67,57 @@ test('log.info("msg", new Error("boom"))', t => {
   t.end()
 })
 
-test('uncaughtException winston log error message', t => {
-  execFile(
-    process.execPath,
-    ['uncaught-exception.js'],
-    {
-      cwd: __dirname,
-      timeout: 5000
-    },
-    function (err, stdout, _stderr) {
-      t.ok(err, 'script exited non-zero')
-      const recs = stdout.trim().split(/\n/g).map(JSON.parse)
-      t.equal(recs.length, 1)
-      const rec = recs[0]
-      t.equal(rec['log.level'], 'error', 'log.level')
-      t.equal(rec.message, 'uncaughtException: funcb boom', 'message')
-      t.equal(rec.error.type, 'Error', 'error.type')
-      t.equal(rec.error.message, 'funcb boom', 'error.message')
-      t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
-      t.equal(rec.error.code, 42, 'error.code')
-      t.equal(rec.exception, true, 'exception')
-      t.end()
-    }
-  )
-})
+if (!TEST_SKIP_SLOW) {
+  test('uncaughtException winston log error message', t => {
+    execFile(
+      process.execPath,
+      ['uncaught-exception.js'],
+      {
+        cwd: __dirname,
+        timeout: 5000
+      },
+      function (err, stdout, _stderr) {
+        t.ok(err, 'script exited non-zero')
+        const recs = stdout.trim().split(/\n/g).map(JSON.parse)
+        t.equal(recs.length, 1)
+        const rec = recs[0]
+        t.equal(rec['log.level'], 'error', 'log.level')
+        t.equal(rec.message, 'uncaughtException: funcb boom', 'message')
+        t.equal(rec.error.type, 'Error', 'error.type')
+        t.equal(rec.error.message, 'funcb boom', 'error.message')
+        t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
+        t.equal(rec.error.code, 42, 'error.code')
+        t.equal(rec.exception, true, 'exception')
+        t.end()
+      }
+    )
+  })
 
-test('unhandledRejection winston log error message', t => {
-  execFile(
-    process.execPath,
-    ['unhandled-rejection.js'],
-    {
-      cwd: __dirname,
-      timeout: 5000
-    },
-    function (err, stdout, _stderr) {
-      t.ok(err, 'script exited non-zero')
-      const recs = stdout.trim().split(/\n/g).map(JSON.parse)
-      t.equal(recs.length, 1)
-      const rec = recs[0]
-      t.equal(rec['log.level'], 'error', 'log.level')
-      t.equal(rec.message, 'unhandledRejection: funcb boom', 'message')
-      t.equal(rec.error.type, 'Error', 'error.type')
-      t.equal(rec.error.message, 'funcb boom', 'error.message')
-      t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
-      t.equal(rec.error.code, 42, 'error.code')
-      t.equal(rec.exception, true, 'exception')
-      t.end()
-    }
-  )
-})
+  test('unhandledRejection winston log error message', t => {
+    execFile(
+      process.execPath,
+      ['unhandled-rejection.js'],
+      {
+        cwd: __dirname,
+        timeout: 5000
+      },
+      function (err, stdout, _stderr) {
+        t.ok(err, 'script exited non-zero')
+        const recs = stdout.trim().split(/\n/g).map(JSON.parse)
+        t.equal(recs.length, 1)
+        const rec = recs[0]
+        t.equal(rec['log.level'], 'error', 'log.level')
+        t.equal(rec.message, 'unhandledRejection: funcb boom', 'message')
+        t.equal(rec.error.type, 'Error', 'error.type')
+        t.equal(rec.error.message, 'funcb boom', 'error.message')
+        t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
+        t.equal(rec.error.code, 42, 'error.code')
+        t.equal(rec.exception, true, 'exception')
+        t.end()
+      }
+    )
+  })
+}
 
 test('log.info(new Error("boom"))', t => {
   const cap = new CaptureTransport()

--- a/utils/check-license-headers.sh
+++ b/utils/check-license-headers.sh
@@ -27,7 +27,7 @@ function check_license_header {
 
 cd "$TOP"
 nErrors=0
-for f in $(git ls-files | grep '\.js$'); do
+for f in $(git ls-files | grep '\.js$' | grep -v fixtures); do
     if ! check_license_header $f; then
         nErrors=$((nErrors+1))
     fi


### PR DESCRIPTION
This updates the three @elastic/ecs-*-format packages to support the following
import styles from JS and TS code:
1. `const { ecsFormat } = require('@elastic/ecs-pino-format);` in JS and TS.
   The preferred import style for JS code using CommonJS.
2. `import { ecsFormat } from '@elastic/ecs-pino-format';` in JS and TS.
   ES module (ESM) import style. This is the preferred style for TypeScript
   code and for JS developers using ESM.
3. `const ecsFormat = require('@elastic/ecs-pino-format');` in JS.
   The old, deprecated import method. Still supported for backward compat.
4. `import ecsFormat from '@elastic/ecs-pino-format';` in JS and TS.
   This works, but is deprecated. Prefer style (2).
5. `import * as EcsPinoFormat from '@elastic/ecs-pino-format';` in TS.
   One must then use `EcsPinoFormat.ecsFormat()`.

Note that this *excludes* support for this TS-only style:
`import escFormat = require('@elastic/ecs-pino-format');`

This also adds types for ecs-morgan-format, based on #119 and #90.
I'd had an earlier start on this in #96.

Replaces: #96
Closes: #90
Closes: #119

---

The functional part of this diff is this in each index.js file:

```diff
+// For backwards compatibility with v1.0.0, the top-level export is `ecsFormat`,
+// though using the named export is preferred.
 module.exports = ecsFormat
+module.exports.ecsFormat = ecsFormat
+module.exports.default = ecsFormat
```

plus the new morgan/index.d.ts file. The rest of the diff is tests, style updates,
and a `npm run test:skip-slow` convenience for dev. Note that I added exhaustive
tests just for ecs-pino-format. I thought it overkill to add "import-styles.test.js"
for the other packages as well.
