### PR TITLE
v1.5.0

### DIFF
--- a/packages/ecs-helpers/package.json
+++ b/packages/ecs-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-helpers",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ecs-logging-nodejs helpers",
   "main": "lib/index.js",
   "files": [

--- a/packages/ecs-morgan-format/CHANGELOG.md
+++ b/packages/ecs-morgan-format/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-morgan-format Changelog
 
-## Unreleased
+## v1.5.0
 
 - Switch to `safe-stable-stringify` for JSON serialization. This library
   protects against circular references and bigints.
@@ -21,12 +21,14 @@
   const ecsFormat = require('@elastic/ecs-morgan-format'); // OLD
   ```
 
-  Changes in this version add support for default import in TypeScript, with or
-  without the `esModuleInterop` setting:
+- Add support for default import in TypeScript, with or without the
+`esModuleInterop` setting:
 
   ```ts
-  import ecsFormat from '@elastic/ecs-morgan-format';
+  import ecsFormat from '@elastic/ecs-pino-format';
   ```
+
+  However, note that using *named* imports is now preferred.
 
 ## v1.4.0
 

--- a/packages/ecs-morgan-format/CHANGELOG.md
+++ b/packages/ecs-morgan-format/CHANGELOG.md
@@ -22,7 +22,7 @@
   ```
 
 - Add support for default import in TypeScript, with or without the
-`esModuleInterop` setting:
+  `esModuleInterop` setting:
 
   ```ts
   import ecsFormat from '@elastic/ecs-pino-format';

--- a/packages/ecs-morgan-format/package.json
+++ b/packages/ecs-morgan-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-morgan-format",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A formatter for the morgan logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/ecs-morgan-format/package.json
+++ b/packages/ecs-morgan-format/package.json
@@ -38,7 +38,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^2.1.0",
+    "@elastic/ecs-helpers": "^2.1.1",
     "safe-stable-stringify": "^2.4.3"
   },
   "devDependencies": {

--- a/packages/ecs-pino-format/CHANGELOG.md
+++ b/packages/ecs-pino-format/CHANGELOG.md
@@ -22,7 +22,7 @@
   ```
 
 - Add support for default import in TypeScript, with or without the
-`esModuleInterop` setting:
+  `esModuleInterop` setting:
 
   ```ts
   import ecsFormat from '@elastic/ecs-pino-format';

--- a/packages/ecs-pino-format/CHANGELOG.md
+++ b/packages/ecs-pino-format/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-pino-format Changelog
 
-## Unreleased
+## v1.5.0
 
 - Bump dep to `@elastic/ecs-helpers@2` which removes the dep on the old
   `fast-safe-stringify` lib that resulted in a maintenance warning about
@@ -21,12 +21,14 @@
   const ecsFormat = require('@elastic/ecs-pino-format'); // OLD
   ```
 
-  Changes in this version add support for default import in TypeScript,
-  with or without the `esModuleInterop` setting:
+- Add support for default import in TypeScript, with or without the
+`esModuleInterop` setting:
 
   ```ts
   import ecsFormat from '@elastic/ecs-pino-format';
   ```
+
+  However, note that using *named* imports is now preferred.
 
 ## v1.4.0
 

--- a/packages/ecs-pino-format/package.json
+++ b/packages/ecs-pino-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-pino-format",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "files": [

--- a/packages/ecs-pino-format/package.json
+++ b/packages/ecs-pino-format/package.json
@@ -40,7 +40,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^2.1.0"
+    "@elastic/ecs-helpers": "^2.1.1"
   },
   "devDependencies": {
     "@types/pino": "^6.3.9",

--- a/packages/ecs-winston-format/CHANGELOG.md
+++ b/packages/ecs-winston-format/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @elastic/ecs-winston-format Changelog
 
-## Unreleased
+## v1.5.0
 
 - Add `ecsFields` and `ecsStringify` exports that are winston formatters
   that separate the gathering of ECS fields (`ecsFields`) and the
@@ -93,6 +93,15 @@
   (https://github.com/elastic/ecs-logging-nodejs/issues/108)
 
 - Set `http.request.id` field (see [ecs-helpers CHANGELOG](../ecs-helpers/CHANGELOG.md#v210)).
+
+- Add support for default import in TypeScript, with or without the
+`esModuleInterop` setting:
+
+  ```ts
+  import ecsFormat from '@elastic/ecs-pino-format';
+  ```
+
+  However, note that using *named* imports is now preferred.
 
 ## v1.4.0
 

--- a/packages/ecs-winston-format/CHANGELOG.md
+++ b/packages/ecs-winston-format/CHANGELOG.md
@@ -95,7 +95,7 @@
 - Set `http.request.id` field (see [ecs-helpers CHANGELOG](../ecs-helpers/CHANGELOG.md#v210)).
 
 - Add support for default import in TypeScript, with or without the
-`esModuleInterop` setting:
+  `esModuleInterop` setting:
 
   ```ts
   import ecsFormat from '@elastic/ecs-pino-format';

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -41,7 +41,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@elastic/ecs-helpers": "^2.1.0",
+    "@elastic/ecs-helpers": "^2.1.1",
     "safe-stable-stringify": "^2.4.3",
     "triple-beam": ">=1.1.0"
   },

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# higlights

- Prefer named exports now: `const { ecsFormat } = require('@elastic/ecs-*-format')`
- Add `http.request.id` field (#76)
- Winston:
    - Add `ecsFields` and `ecsStringify` exports for more composable loggers (#57)
    - Improve serialization of `Error`s (#128)
    - Switch to `safe-stable-stringify` for JSON serialization (#155)
- Morgan:
    - Switch to `safe-stable-stringify` for JSON serialization (#155)

# changelogs

- https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-pino-format/CHANGELOG.md#v150
- https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-winston-format/CHANGELOG.md#v150
- https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-morgan-format/CHANGELOG.md#v150
