### PR TITLE
fixes: #169 Add missing d.ts file in ecs-morgan-format

### DIFF
--- a/packages/ecs-morgan-format/package.json
+++ b/packages/ecs-morgan-format/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixes #169
Added missing index.d.ts file in package.json files property so it will be added in next release. 