### PR TITLE
fix(winston): fix unhandledRejection handling for winston@3.12.0 changes; release @elastic/ecs-winston-format@1.5.3

### DIFF
--- a/packages/ecs-winston-format/CHANGELOG.md
+++ b/packages/ecs-winston-format/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @elastic/ecs-winston-format Changelog
 
+## v1.5.3
+
+- Fix format handling for the log record emitted by Winston for
+  `unhandledRejection` events (when configured to handle them) as of
+  winston@3.12.0. In that version the log record changed slightly to
+  set `record.rejection` rather than `record.exception`.
+
 ## v1.5.2
 
 - Fix the Winston transformers to *not* delete the `level` property from the

--- a/packages/ecs-winston-format/index.js
+++ b/packages/ecs-winston-format/index.js
@@ -65,11 +65,11 @@ class EcsFieldsTransform {
     //    in place of `info.stack`.
     //
     // 2. Winston logger configured to handle uncaughtException and/or unhandledRejection.
-    //    If `info.exception: true` and level is "error" and `info.trace` is an
-    //    Array and `info.message` starts with "uncaughtException:" or
-    //    "unhandledRejection:", then convert to `error.*` fields. These
-    //    conditions are to infer the `info` shape returned by Winston's
-    //    `ExceptionHandler` and `RejectionHandler`.
+    //    If `info.exception: true` or `info.rejection: true`, and level is
+    //    "error",  and `info.trace` is an Array and `info.message` starts with
+    //    "uncaughtException:" or "unhandledRejection:", then convert to
+    //    `error.*` fields. These conditions are to infer the `info` shape
+    //    returned by Winston's `ExceptionHandler` and `RejectionHandler`.
     //    In this case the redundant `stack`, `trace`, `date` fields are dropped
     //    and error details are moved to the `error.*` fields.
     //
@@ -99,7 +99,8 @@ class EcsFieldsTransform {
       for (const propName in err) {
         delete info[propName]
       }
-    } else if (info.exception === true &&
+    } else if (
+      (info.exception === true || info.rejection === true) &&
       info.level === 'error' &&
       Array.isArray(info.trace) &&
       (info.message.startsWith('uncaughtException:') ||

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-winston-format",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/ecs-winston-format/test/errors.test.js
+++ b/packages/ecs-winston-format/test/errors.test.js
@@ -112,7 +112,13 @@ if (!TEST_SKIP_SLOW) {
         t.equal(rec.error.message, 'funcb boom', 'error.message')
         t.match(rec.error.stack_trace, /^Error: funcb boom\n {4}at/, 'error.stack_trace')
         t.equal(rec.error.code, 42, 'error.code')
-        t.equal(rec.exception, true, 'exception')
+        if (semver.gte(winston.version, '3.12.0')) {
+          // https://github.com/winstonjs/winston/pull/2390 changed behaviour
+          // with unhandledRejection in winston@3.12.0.
+          t.equal(rec.rejection, true, 'rejection')
+        } else {
+          t.equal(rec.exception, true, 'exception')
+        }
         t.end()
       }
     )


### PR DESCRIPTION
In winston@3.12.0, the handling of unhandledRejection events changed
slightly: setting '<record>.rejection=true` rather than `<record>.exception`.

* * *

This changed in https://github.com/winstonjs/winston/pull/2390.
This is the reason for the CI failures seen on the unrelated https://github.com/elastic/ecs-logging-nodejs/pull/180 PR.

I will do a v1.5.3 release for  this.