### PR TITLE
release: automate the release for this project

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -1,0 +1,35 @@
+---
+
+name: npm/publish
+description: common build tasks for npm publish
+
+inputs:
+  node-version:
+    description: 'Nodejs version'
+    required: false
+    default: 'v18.20.2'
+  package:
+    description: 'The npm package'
+    required: true
+  npm-token:
+    description: 'The NPMJS token'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'v18.20.2'
+        registry-url: 'https://registry.npmjs.org'
+
+    - run: npm ci --ignore-scripts
+      shell: 'bash'
+
+    - name: npm publish
+      working-directory: ./packages/${{ inputs.package}}
+      run: npm publish
+      shell: 'bash'
+      env:
+        # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}

--- a/.github/workflows/release-ecs-helpers.yml
+++ b/.github/workflows/release-ecs-helpers.yml
@@ -1,0 +1,36 @@
+# Release a tagged version of the '@elastic/ecs-helpers' package.
+name: release
+
+on:
+  push:
+    tags:
+      - ecs-helpers-v*.*.*
+
+# 'id-token' perm needed for npm publishing with provenance (see
+# https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
+permissions:
+  contents: write
+  pull-requests: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/npm-publish
+        with:
+          node-version: 'v18.20.2'
+          npm-token: 'ecs-helpers'
+          package: ${{ matrix.package }}
+
+      - name: Notify in Slack
+        if: ${{ failure() }}
+        uses: elastic/oblt-actions/slack/notify-result@v1
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-node"
+          message: '[${{ github.repository }}] Release `@elastic/ecs-helpers` *${{ github.ref_name }}*'

--- a/.github/workflows/release-ecs-helpers.yml
+++ b/.github/workflows/release-ecs-helpers.yml
@@ -1,5 +1,5 @@
 # Release a tagged version of the '@elastic/ecs-helpers' package.
-name: release
+name: release-ecs-helpers
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# Release a tagged version of the '@elastic/ecs-[...]-format' packages.
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+# 'id-token' perm needed for npm publishing with provenance (see
+# https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow)
+permissions:
+  contents: write
+  pull-requests: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ["ecs-morgan-format", "ecs-pino-format", "ecs-winston-format"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/npm-publish
+        with:
+          node-version: 'v18.20.2'
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          package: ${{ matrix.package }}
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - id: check
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - name: Notify in Slack
+        # Only notify on failure, because on success the published GitHub
+        # Release will result in a notification from the GitHub Slack app
+        # (assuming '/github subscribe elastic/elastic-otel-node').
+        if: ${{ steps.check.outputs.status == 'failure' }}
+        uses: elastic/oblt-actions/slack/notify-result@v1.12.0
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-node"
+          message: '[${{ github.repository }}] Release `@elastic/ecs-[...]-format` packages *${{ github.ref_name }}*'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,11 +22,15 @@ Assuming "x.y.z" is the release version:
       changes, then the commit/PR title should include mention of those
       things as well.)
 3. Get the PR approved and merged.
-4. Tag the commit as follows, in a git clone with the merged commit:
+
+4. Working on the elastic repo (not a fork), tag the commit as follows:
     ```
     git tag ecs-helpers-vx.y.z
     git push origin ecs-helpers-vx.y.z
     ```
+    The GitHub Actions "release-ecs-helpers" workflow will handle the release
+    steps -- including the `npm publish`. See the appropriate run at:
+    https://github.com/elastic/ecs-logging-nodehs/actions/workflows/release-ecs-helpers.yml
 
 5. The automation will do the rest.
 
@@ -68,11 +72,14 @@ below command in a clean git clone:
 
 3. Get the PR approved and merged.
 
-4. Tag the commit as follows, in a git clone with the merged commit:
+4. Working on the elastic repo (not a fork), tag the commit as follows:
     ```
     git tag vx.y.z
     git push origin vx.y.z
     ```
+    The GitHub Actions "release" workflow will handle the release
+    steps -- including the `npm publish`. See the appropriate run at:
+    https://github.com/elastic/ecs-logging-nodehs/actions/workflows/release.yml
 
 5. The automation will do the rest.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,12 +27,18 @@ Assuming "x.y.z" is the release version:
     git tag ecs-helpers-vx.y.z
     git push origin ecs-helpers-vx.y.z
     ```
-5. Publish to npm, in a clean git clone:
+
+5. The automation will do the rest.
+
+If for any reason you need to run the publish the package manually then run the
+below command in a clean git clone:
     ```
     git status              # this should show "working tree clean"
+
     cd packages/ecs-helpers
     npm publish
     ```
+
 
 ## Releasing `@elastic/ecs-[...]-format`
 
@@ -68,7 +74,10 @@ Assuming "x.y.z" is the release version:
     git push origin vx.y.z
     ```
 
-5. Publish to npm, in a clean git clone:
+5. The automation will do the rest.
+
+If for any reason you need to run the publish the package manually then run the
+below command in a clean git clone:
     ```
     git status              # this should show "working tree clean"
 
@@ -76,4 +85,3 @@ Assuming "x.y.z" is the release version:
     cd packages/ecs-...-format
     npm publish
     ```
-

--- a/packages/ecs-helpers/package.json
+++ b/packages/ecs-helpers/package.json
@@ -2,6 +2,10 @@
   "name": "@elastic/ecs-helpers",
   "version": "2.1.1",
   "description": "ecs-logging-nodejs helpers",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/packages/ecs-morgan-format/package.json
+++ b/packages/ecs-morgan-format/package.json
@@ -2,6 +2,10 @@
   "name": "@elastic/ecs-morgan-format",
   "version": "1.5.1",
   "description": "A formatter for the morgan logger compatible with Elastic Common Schema.",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "types": "index.d.ts",
   "files": [

--- a/packages/ecs-pino-format/package.json
+++ b/packages/ecs-pino-format/package.json
@@ -2,6 +2,10 @@
   "name": "@elastic/ecs-pino-format",
   "version": "1.5.0",
   "description": "A formatter for the pino logger compatible with Elastic Common Schema.",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "files": [
     "index.js",

--- a/packages/ecs-winston-format/package.json
+++ b/packages/ecs-winston-format/package.json
@@ -2,6 +2,10 @@
   "name": "@elastic/ecs-winston-format",
   "version": "1.5.3",
   "description": "A formatter for the winston logger compatible with Elastic Common Schema.",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "index.js",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
I took some of the changes done in https://github.com/elastic/elastic-otel-node/pull/138
and enable the automation to release through Github workflows using a service machine account.

I also created two different workflows:
- the one supporting the ecs-helpers package
- the other one supporting the other packages.

