### PR TITLE
feat: include error.id and error.code in formatError, @elastic/ecs-helpers@2.2.0

### DIFF
--- a/packages/ecs-helpers/CHANGELOG.md
+++ b/packages/ecs-helpers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @elastic/ecs-helpers Changelog
 
+## v2.2.0
+
+- `formatError()` now includes the [`error.id`](https://www.elastic.co/docs/reference/ecs/ecs-error#field-error-id)
+  and [`error.code`](https://www.elastic.co/docs/reference/ecs/ecs-error#field-error-code)
+  fields on the emitted `error` object when the source `Error` instance has
+  matching `id` or `code` properties. Previously these were silently dropped,
+  even though they are part of the ECS [error field set](https://www.elastic.co/docs/reference/ecs/ecs-error).
+
 ## v2.1.1
 
 - fix: Use `req.originalUrl`, if available, when converting `req` to ECS fields.

--- a/packages/ecs-helpers/lib/error-formatters.js
+++ b/packages/ecs-helpers/lib/error-formatters.js
@@ -35,6 +35,12 @@ function formatError (ecsFields, err) {
     message: err.message,
     stack_trace: err.stack
   }
+  if (err.code !== undefined) {
+    ecsFields.error.code = err.code
+  }
+  if (err.id !== undefined) {
+    ecsFields.error.id = err.id
+  }
 
   return true
 }

--- a/packages/ecs-helpers/package.json
+++ b/packages/ecs-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ecs-helpers",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "ecs-logging-nodejs helpers",
   "publishConfig": {
     "access": "public",

--- a/packages/ecs-helpers/test/basic.test.js
+++ b/packages/ecs-helpers/test/basic.test.js
@@ -265,6 +265,25 @@ test('formatError: MyError with removed constructor', t => {
   t.end()
 })
 
+test('formatError: Error with code and id', t => {
+  const rec = {}
+  const err = new Error('boom')
+  err.code = 'ESOMETHING'
+  err.id = 'req-123'
+  formatError(rec, err)
+  t.equal(rec.error.code, 'ESOMETHING')
+  t.equal(rec.error.id, 'req-123')
+  t.end()
+})
+
+test('formatError: Error without code or id', t => {
+  const rec = {}
+  formatError(rec, new Error('boom'))
+  t.notOk('code' in rec.error, 'error.code should be absent')
+  t.notOk('id' in rec.error, 'error.id should be absent')
+  t.end()
+})
+
 test('formatError: non-Error', t => {
   const rec = {}
   const nonError = { foo: 'bar' }


### PR DESCRIPTION
### Why?

The ECS [error field set](https://www.elastic.co/docs/reference/ecs/ecs-error) includes `error.id` and `error.code` alongside `error.type`, `error.message`, and `error.stack_trace`. `formatError()` was only emitting the latter three, so any `id`/`code` properties on the source `Error` (for example Node system errors with `err.code === 'ENOENT'`) were silently dropped.

### How?

Copy `err.code` and `err.id` onto the emitted `error` object when they are defined on the source `Error`, guarded so plain errors keep the same minimal shape as before. Values pass through as-is — matching the existing behavior in `ecs-winston-format`, which already surfaces `err.code` via `Object.assign({}, err)`.

Picked up automatically by `@elastic/ecs-pino-format` via its call to `formatError`. `ecs-winston-format` and `ecs-morgan-format` do not call `formatError` and are unaffected. Bumped `@elastic/ecs-helpers` to `v2.2.0` and added a matching CHANGELOG entry.